### PR TITLE
Fix changePassword

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you get the client with `<script src="/hoodie/client.js"></script>`, then the
 - [cryptoStore (setup function)](#cryptostore-setup-function)
 - [cryptoStore.setPassword(password)](#cryptostoresetpasswordpassword)
 - [cryptoStore.setPassword(password, salt)](#cryptostoresetpasswordpassword-salt)
+- [cryptoStore.changePassword(oldPassword, newPassword)](#cryptostorechangepasswordoldpassword-newpassword)
 - [cryptoStore.add(properties)](#cryptostoreaddproperties)
 - [cryptoStore.add(arrayOfProperties)](#cryptostoreaddarrayofproperties)
 - [cryptoStore.find(id)](#cryptostorefindid)
@@ -234,6 +235,20 @@ function signIn (accountProperties, encryptionPW) {
     })
 }
 ```
+
+### cryptoStore.changePassword(oldPassword, newPassword)
+
+```javascript
+cryptoStore.changePassword(oldPassword, newPassword)
+```
+
+Argument      | Type   | Description    | Required
+--------------|--------|----------------|---------
+`oldPassword` | String | The old password, that was used up until now | Yes
+`newPassword` | String | New password, with which the docs will be encrypted | Yes
+
+Resolves with a new `salt`. It will update all with `oldPassword` encrypted documents. And encrypt
+them with with the help of the `newPassword`. It also updates the `salt` in `_design/cryptoStore/salt`.
 
 ### cryptoStore.add(properties)
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ Argument      | Type   | Description    | Required
 `oldPassword` | String | The old password, that was used up until now | Yes
 `newPassword` | String | New password, with which the docs will be encrypted | Yes
 
-Resolves with a new `salt`. It will update all with `oldPassword` encrypted documents. And encrypt
-them with with the help of the `newPassword`. It also updates the `salt` in `_design/cryptoStore/salt`.
+Resolves with an object with the new `salt` and an array (`notUpdated`) with the ids of not updated docs.
+It will update all with `oldPassword` encrypted documents. And encrypt them with with the help of
+the `newPassword`. It also updates the `salt` in `_design/cryptoStore/salt`.
 
 Rejects with:
 
@@ -258,8 +259,10 @@ Error |	...
 
 Example
 ```javascript
-hoodie.cryptoStore.changePassword('my-old-password', 'secret').then(function (salt) {
+hoodie.cryptoStore.changePassword('my-old-password', 'secret').then(function (report) {
   console.log('all documents are updated!')
+  console.log(report.salt) // the new salt
+  console.log(report.notUpdated) // array with all ids of encrypted docs that hasn't been updated
 }).catch(function (error) {
   console.error(error)
 })

--- a/README.md
+++ b/README.md
@@ -250,6 +250,21 @@ Argument      | Type   | Description    | Required
 Resolves with a new `salt`. It will update all with `oldPassword` encrypted documents. And encrypt
 them with with the help of the `newPassword`. It also updates the `salt` in `_design/cryptoStore/salt`.
 
+Rejects with:
+
+Name 	| Description
+------|--------
+Error |	...
+
+Example
+```javascript
+hoodie.cryptoStore.changePassword('my-old-password', 'secret').then(function (salt) {
+  console.log('all documents are updated!')
+}).catch(function (error) {
+  console.error(error)
+})
+```
+
 ### cryptoStore.add(properties)
 
 ```javascript

--- a/lib/change-password.js
+++ b/lib/change-password.js
@@ -4,7 +4,7 @@ var Promise = require('lie')
 
 var createKey = require('./create-key')
 var isEncryptedObject = require('./utils/is-encrypted-object')
-var decryptMany = require('./helpers/decrypt-many')
+var decryptOne = require('./helpers/decrypt-one')
 var encryptMany = require('./helpers/encrypt-many')
 
 module.exports = changePassword
@@ -45,6 +45,8 @@ function changePassword (store, state, oldPassword, newPassword) {
     })
 
     .then(function (data) {
+      var notDecrypted = [] // will store the ids of docs that couldn't be decrypted/updated
+
       // update old encrypted docs
       return store.db.allDocs({include_docs: true})
 
@@ -55,11 +57,38 @@ function changePassword (store, state, oldPassword, newPassword) {
             })
             .filter(isEncryptedObject)
 
-          return decryptMany(data.oldKey, filtered)
+          var decrypted = filtered
+            .map(function (doc) {
+              return decryptOne(data.oldKey, doc)
+
+                .catch(function (error) {
+                  if (error.message === 'Unsupported state or unable to authenticate data') {
+                    return doc._id
+                  }
+                  throw error
+                })
+            })
+
+          return Promise.all(decrypted)
         })
 
-        .then(function (decryped) {
-          return encryptMany(data.newKey, null, decryped)
+        .then(function (decrypted) {
+          return decrypted.reduce(function (all, doc) {
+            if (typeof doc === 'string') {
+              all.notDecrypted.push(doc)
+            } else {
+              all.decrypted.push(doc)
+            }
+            return all
+          }, {
+            decrypted: [],
+            notDecrypted: []
+          })
+        })
+
+        .then(function (result) {
+          notDecrypted = result.notDecrypted
+          return encryptMany(data.newKey, null, result.decrypted)
         })
 
         .then(function (toUpdate) {
@@ -71,7 +100,10 @@ function changePassword (store, state, oldPassword, newPassword) {
         })
 
         .then(function (updated) {
-          return data.newSalt
+          return {
+            salt: data.newSalt,
+            notUpdated: notDecrypted
+          }
         })
     })
 }


### PR DESCRIPTION
Proposed changes:

- changePassword() will only update docs that it can decrypt. This will make it usable if withPassword() was used!
- changePassword() will resolve with an object, containing `salt` and `notUpdated`, an array containing all `ids` of not updated objects.