### PR TITLE
Dont change

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ corresponding methods from Hoodie to save them.
 
 There is no server side to this plugin!
 
-**Everything of a doc will be encrypted, except `_id`, `_rev`, `_deleted` and the `hoodie` object!**
+**Everything of a doc will be encrypted, except `_id`, `_rev`, `_deleted`, `_attachments`, `_conflicts` and the `hoodie` object!**
 
 ## Example
 ```js
@@ -232,7 +232,7 @@ This plugin uses the `sha256` and `pbkdf2` algorithm for generating a key from y
 
 ### What is encrypted
 
-Hoodie, CouchDB and PouchDB need `_id`, `_rev` and `_deleted` to function. They and the content of the `hoodie` object, are **not encrypted**!
+Hoodie, CouchDB and PouchDB need `_id`, `_rev`, `_deleted`, `_attachments` and `_conflicts` to function. They and the content of the `hoodie` object, are **not encrypted**!
 Everything else is run through `JSON.stringify` and encrypted.
 
 **_Please be aware, that the `_id` of a doc is not encrypted! Don't store important or personal information in the `_id`!_**

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -3,6 +3,8 @@
 var nativeCrypto = require('native-crypto')
 var randomBytes = require('randombytes')
 var uuid = require('uuid').v4
+var keys = require('lodash/keys')
+var includes = require('lodash/includes')
 
 var ignore = require('./utils/ignore.js')
 
@@ -12,12 +14,23 @@ module.exports = encryptDoc
 function encryptDoc (key, doc, prefix) {
   var nonce = randomBytes(12)
   var outDoc = {
+    _id: '',
+    _rev: '',
+    hoodie: null,
+    tag: '',
+    data: '',
     nonce: nonce.toString('hex')
   }
+  var encryptDoc = {}
 
-  ignore.forEach(function (key) {
-    outDoc[key] = doc[key]
-    delete doc[key]
+  keys(doc).forEach(function (key) {
+    if (doc[key] === undefined) return
+
+    if (includes(ignore, key)) {
+      outDoc[key] = doc[key]
+    } else {
+      encryptDoc[key] = doc[key]
+    }
   })
 
   if (!outDoc._id) {
@@ -27,13 +40,7 @@ function encryptDoc (key, doc, prefix) {
     outDoc._id = prefix + outDoc._id
   }
 
-  // Encrypting attachments is complicated
-  // https://github.com/calvinmetcalf/crypto-pouch/pull/18#issuecomment-186402231
-  if (doc._attachments) {
-    throw new Error('Attachments cannot be encrypted. Use {ignore: "_attachments"} option')
-  }
-
-  var data = JSON.stringify(doc)
+  var data = JSON.stringify(encryptDoc)
   return nativeCrypto.encrypt(key, nonce, data, Buffer.from(outDoc._id))
 
     .then(function (response) {

--- a/lib/utils/ignore.js
+++ b/lib/utils/ignore.js
@@ -4,5 +4,7 @@ module.exports = [
   '_id',
   '_rev',
   '_deleted',
+  '_attachments',
+  '_conflicts',
   'hoodie'
 ]

--- a/tests/unit/encrypt-test.js
+++ b/tests/unit/encrypt-test.js
@@ -57,3 +57,66 @@ test('should throw with a TypeError if no key is passed', function (t) {
       t.is(error.name, 'TypeError')
     })
 })
+
+test("shouldn't change the original object", function (t) {
+  t.plan(3)
+
+  var doc = {
+    _id: 'hello',
+    _rev: '1-1234567890',
+    hoodie: {
+      createdAt: new Date().toJSON()
+    },
+    foo: 'bar',
+    hello: 'world',
+    day: 1
+  }
+  var key = Buffer.from('8ecab44b2448d6bae235476a134be8f6bec705a35a02dea3afb4e648f29eb66c', 'hex')
+  var docData = JSON.stringify(doc)
+
+  encrypt(key, doc)
+
+    .then(function (result) {
+      t.equal(JSON.stringify(doc), docData, 'unchanged')
+      t.equal(doc._id, 'hello', "_id didn't change")
+      t.equal(doc._rev, '1-1234567890', "_rev didn't change")
+    })
+})
+
+test('should ignore properties in ignore', function (t) {
+  t.plan(6)
+
+  var doc = {
+    _id: 'hello',
+    _rev: '2-1234567890',
+    _deleted: false,
+    _attachments: {
+      'info.txt': {
+        'content_type': 'text/plain',
+        'digest': 'd5ccfd24a8748bed4e2c9a279a2b6089',
+        'data': 'SXMgdGhlcmUgbGlmZSBvbiBNYXJzPw=='
+      }
+    },
+    _conflicts: [
+      '2-0987654321'
+    ],
+    hoodie: {
+      createdAt: new Date().toJSON()
+    },
+    foo: 'bar',
+    hello: 'world',
+    day: 1
+  }
+  var key = Buffer.from('8ecab44b2448d6bae235476a134be8f6bec705a35a02dea3afb4e648f29eb66c', 'hex')
+
+  encrypt(key, doc)
+
+    .then(function (result) {
+      t.equal(result._id, 'hello', "_id didn't change")
+      t.equal(result._rev, '2-1234567890', "_rev didn't change")
+      t.equal(result._deleted, false, "_deleted didn't change")
+      t.equal(result._attachments, doc._attachments, "_attachments didn't change")
+      t.equal(result._conflicts, doc._conflicts, "_conflicts didn't change")
+      t.equal(result.hoodie, doc.hoodie, "hoodie didn't change")
+    })
+})


### PR DESCRIPTION
Fixes #35.

Changes proposed in this pull request:

- Original Object that should be encrypted, is not modified
- Add `_attachments` and `_conflicts` to the ignore list
- Don't throw if `_attachments` are present
