### PR TITLE
No full hoodie-client

### DIFF
--- a/hoodie/client.js
+++ b/hoodie/client.js
@@ -31,5 +31,11 @@ function cryptoStore (hoodie, options) {
 
   hoodie.cryptoStore = bindFunctions(hoodie.store, state, null, handler, true)
 
-  hoodie.account.on('signout', hoodie.cryptoStore.lock)
+  if ('account' in hoodie && typeof hoodie.account.on === 'function') {
+    hoodie.account.on('signout', hoodie.cryptoStore.lock)
+  } else {
+    console.warn(
+      "Couldn't find hoodie.account.on\n\nhoodie-plugin-store-crypto will not lock on signout!"
+    )
+  }
 }

--- a/lib/unlock.js
+++ b/lib/unlock.js
@@ -39,9 +39,19 @@ function unlock (store, state, password) {
   // get updated salt docs from remote
   return store.pull(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
 
-    .then(function () {
-      return store.find(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
-    })
+    .then(
+      function () {
+        return store.find(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+      },
+      function (error) {
+        return store.find(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+
+          .then(function (result) {
+            console.warn("Couldn't pull salt-docs from remote. Using local salt!\nError: " + error)
+            return result
+          })
+      }
+    )
 
     .then(function (objects) {
       // if the old salt doc exists: delete it

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,7 @@ require('./unit/encrypt-test')
 require('./unit/decrypt-test')
 require('./unit/lock')
 
+require('./integration/plugin')
 require('./integration/crypto-test')
 require('./integration/setup')
 require('./integration/unlock')

--- a/tests/integration/plugin.js
+++ b/tests/integration/plugin.js
@@ -1,0 +1,56 @@
+var test = require('tape')
+var Store = require('@hoodie/store-client')
+
+var cryptoStore = require('../../')
+
+var PouchDB = require('../utils/pouchdb.js')
+var uniqueName = require('../utils/unique-name')
+
+test('cryptoStore should listen to account/signout events', function (t) {
+  t.plan(3)
+
+  var name = uniqueName()
+  var hoodie = {
+    account: null,
+    store: new Store(name, {
+      PouchDB: PouchDB,
+      remote: 'remote-' + name
+    })
+  }
+
+  hoodie.account = {
+    on: function (eventName, handler) {
+      t.equal(eventName, 'signout', 'eventName is signout')
+      t.equal(typeof handler, 'function', 'handler is a function')
+      t.equal(handler, hoodie.cryptoStore.lock, 'handler is cryptoStore.lock')
+    }
+  }
+
+  try {
+    cryptoStore(hoodie)
+  } catch (err) {
+    t.end(err)
+  }
+})
+
+test('cryptoStore should work with a not complete Hoodie-client', function (t) {
+  t.plan(1)
+
+  var name = uniqueName()
+
+  var hoodie = {
+    // no account
+    store: new Store(name, {
+      PouchDB: PouchDB,
+      remote: 'remote-' + name
+    })
+  }
+
+  try {
+    cryptoStore(hoodie)
+
+    t.ok(hoodie.cryptoStore, 'cryptoStore exists')
+  } catch (err) {
+    t.end(err)
+  }
+})


### PR DESCRIPTION
Fixes problems with no account field in the hoodie object and unlock not working if offline/not signed in.

Changes proposed in this pull request:

- Only listen to `signout`-events if a `account`-field exists on the hoodie-client object.
- Use local salt docs if new ones couldn't be pulled from the server.

Reviewer: @Terreii
