### PR TITLE
Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
+  - "12"
   - "node"
 
 # Trigger a push build on latest and greenkeeper branches + PRs build on every branches

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ corresponding methods from Hoodie to save them.
 
 There is no server side to this plugin!
 
-**Everything of a doc will get encrypted. Except for `_id`, `_rev`, `_deleted`, `_attachments`, `_conflicts` and the `hoodie` object! And optionally _all keys that start with an underscore (\_) will not get encrypted_!**
+**Everything of a doc will get encrypted. Except for `_id`, `_rev`, `_deleted`, `_attachments`, `_conflicts` and the `hoodie` object! And _all keys that start with an underscore (\_) will not get encrypted_!**
 
 Read more in the [API Docs](docs/api.md#what-gets-encrypted).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -162,6 +162,7 @@ Argument | Type   | Description | Required
 ---------|--------|-------------|----------
 `hoodie` | Object | Hoodie client instance | Yes
 `options.noPasswordCheckAutoFix` | Boolean | [Deactivate password-check autofix](#v2-update-notes). Default is `false` | No
+`options.notHandleSpecialDocumentMembers` | Boolean | [Encrypt all fields with a key that start with an `_`](#what-gets-encrypted). Default is `false` | No
 
 Returns `undefined`
 
@@ -450,7 +451,7 @@ Argument      | Type   | Description                                     | Requi
 `properties`  | Object | properties of document                          | Yes
 `properties._id` | String | If set, the document will be stored at given id | No
 
-Resolves with `properties` unencrypted and adds `id` (unless provided). And adds a `hoodie` property with `createdAt` and `updatedAt` properties. It will get encrypted.
+Resolves with decrypted `properties` and adds `id` (unless provided). And adds a `hoodie` property with `createdAt` and `updatedAt` properties. It will get encrypted.
 
 ```JSON
 {
@@ -492,7 +493,7 @@ Argument          | Type  | Description      | Required
 
 It adds `_id` (unless provided) and a `hoodie` property with `createdAt` and `updatedAt` properties. And encrypts them.
 
-Resolves with an array of the added documents, unencrypted.
+Resolves with an array of the added documents, decrypted.
 
 ```JSON
 [
@@ -536,7 +537,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `id`    | String | Unique id of the document  | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents.
 
 ```JSON
 {
@@ -578,7 +579,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `doc`   | Object | Document with `_id` property  | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents.
 
 ```JSON
 {
@@ -620,7 +621,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `idsOrDocs` | Array | Array of `id` (String) or `doc` (Object) items  | Yes
 
-Resolves with array of `properties` unencrypted. Works on encrypted and unencrypted documents.
+Resolves with array of decrypted `properties`. Works on encrypted and not encrypted documents.
 
 ```JSON
 [
@@ -668,7 +669,7 @@ Argument| Type  | Description      | Required
 `id`    | String | Unique id of the document  | Yes
 `doc`   | Object | Document that will be saved if no document with the id exists | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents. If doc gets added, it will also encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents. If doc gets added, it will also encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties.
 
 Rejects with:
 
@@ -699,7 +700,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `doc`   | Object | Document  with `_id` property | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents. If doc gets added, it will also encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents. If doc gets added, it will also encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties.
 
 Rejects with:
 
@@ -730,7 +731,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `idsOrDocs` | Array | Array of documents with `_id` property or ids | Yes
 
-Resolves with an array of `properties` unencrypted. Works on encrypted and unencrypted documents. If a doc gets added, it will also encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties.
+Resolves with an array of decrypted `properties`. Works on encrypted and not encrypted documents. If a doc gets added, it will also encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties.
 
 Rejects with:
 
@@ -764,7 +765,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `filterFunction` | Function | Function that will be called for every doc with `doc`, `index` and `arrayOfAllDocs`. And returns `true` if `doc` should be returned, `false` if not. | No
 
-Resolves with array of `properties` unencrypted. Works on encrypted and unencrypted documents.
+Resolves with array of decrypted `properties`. Works on encrypted and not encrypted documents.
 
 ```JSON
 [
@@ -812,7 +813,7 @@ Argument| Type  | Description      | Required
 `id`    | String | Unique id of the document  | Yes
 `changedProperties` | Object | Properties that should be changed | Yes
 
-Resolves with updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with updated decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 Rejects with:
 
@@ -848,7 +849,7 @@ Argument| Type  | Description      | Required
 `id`    | String | Unique id of the document  | Yes
 `updateFunction` | Function | Function that get the document passed and changes the document. | Yes
 
-Resolves with updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with updated and decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 Rejects with:
 
@@ -885,7 +886,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `doc`   | Object | Properties that should be changed with a `_id` property | Yes
 
-Resolves with updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with updated and decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 Rejects with:
 
@@ -920,7 +921,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `arrayOfDocs` | Array | Array properties that should be changed with a `_id` property | Yes
 
-Resolves with an array of updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with an array of updated and decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 Rejects with:
 
@@ -959,7 +960,7 @@ Argument| Type  | Description      | Required
 `id`    | String | Unique id of the document  | Yes
 `doc`   | Object | Properties that should be changed or added if doc doesn't exist | Yes
 
-Resolves with updated `properties` unencrypted. Updates existing documents and adds nonexistent docs. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted! If the doc gets added, it will encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties added.
+Resolves with updated and decrypted `properties`. Updates existing documents and adds nonexistent docs. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted! If the doc gets added, it will encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties added.
 
 Rejects with:
 
@@ -990,7 +991,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `doc`   | Object | Properties that should be changed or added with a `_id` property | Yes
 
-Resolves with updated `properties` unencrypted. Updates existing documents and adds nonexistent docs. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted! If the doc gets added, it will encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties added.
+Resolves with updated and decrypted `properties`. Updates existing documents and adds nonexistent docs. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted! If the doc gets added, it will encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties added.
 
 Rejects with:
 
@@ -1024,7 +1025,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `arrayOfDocs` | Array | Array properties that should be changed or added with a `_id` property | Yes
 
-Resolves with an array of updated `properties` unencrypted. Updates existing documents and adds nonexistent docs. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted! If the doc gets added, it will encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties added.
+Resolves with an array of updated and decrypted `properties`. Updates existing documents and adds nonexistent docs. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted! If the doc gets added, it will encrypt it and add a `hoodie` property with `createdAt` and `updatedAt` properties added.
 
 Rejects with:
 
@@ -1061,7 +1062,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `changedProperties` | Object | Properties that should be changed by all documents | Yes
 
-Resolves with updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with updated and decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 __This updates and encrypts all documents with its idPrefix!__
 
@@ -1102,7 +1103,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `updateFunction` | Function | Function that get the document passed and changes the document. | Yes
 
-Resolves with updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with updated and decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 __This updates and encrypts all documents with its idPrefix!__
 
@@ -1147,7 +1148,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `id`    | String | Unique id of the document  | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents. It set the document to deleted. Unencrypted documents will get encrypted! It adds `deletedAt` to the `hoodie` property.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents. It set the document to deleted. Not encrypted documents will get encrypted! It adds `deletedAt` to the `hoodie` property.
 
 ```JSON
 {
@@ -1191,7 +1192,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `doc`   | Object | Properties that should be changed with a `_id` property | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents. It set the document to deleted and updates `properties`. Unencrypted documents will get encrypted! It adds `deletedAt` to the `hoodie` property.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents. It set the document to deleted and updates `properties`. Not encrypted documents will get encrypted! It adds `deletedAt` to the `hoodie` property.
 
 ```JSON
 {
@@ -1239,7 +1240,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `idsOrDocs`  | Array | Properties that should be changed with a `_id` property or ids | Yes
 
-Resolves with `properties` unencrypted. Works on encrypted and unencrypted documents. It set the document to deleted and updates `properties`. Unencrypted documents will get encrypted! It adds `deletedAt` to the `hoodie` property.
+Resolves with decrypted `properties`. Works on encrypted and not encrypted documents. It set the document to deleted and updates `properties`. Not encrypted documents will get encrypted! It adds `deletedAt` to the `hoodie` property.
 
 ```JSON
 [
@@ -1289,7 +1290,7 @@ Argument| Type  | Description      | Required
 --------|-------|--------------------------|----------
 `filterFunction` | Function | Function that will be called for every doc with `doc`, `index` and `arrayOfAllDocs`. And returns `true` if `doc` should be returned, `false` if not. | No
 
-Resolves with updated `properties` unencrypted. Works on encrypted and unencrypted documents. Unencrypted documents will get encrypted!
+Resolves with updated and decrypted `properties`. Works on encrypted and not encrypted documents. Not encrypted documents will get encrypted!
 
 ```JSON
 [
@@ -1401,7 +1402,7 @@ function isEncrypted (id) {
 cryptoStore.on(eventName, handler)
 ```
 
-Add an event-handler. It behaves like [hoodie-store-client's on](https://github.com/hoodiehq/hoodie-store-client#storeon). But will not emit events for unencrypted documents or documents it couldn't decrypted. It will also decrypt the document.
+Add an event-handler. It behaves like [hoodie-store-client's on](https://github.com/hoodiehq/hoodie-store-client#storeon). But will not emit events for not encrypted documents or documents it couldn't decrypted. It will also decrypt the document.
 
 Argument| Type  | Description      | Required
 --------|-------|------------------|----------
@@ -1435,7 +1436,7 @@ hoodie.cryptoStore.on('change', changeHandler)
 cryptoStore.one(eventName, handler)
 ```
 
-Add an one-time event-handler. It behaves like [hoodie-store-client's one](https://github.com/hoodiehq/hoodie-store-client#storeone). But will not emit events for unencrypted documents or documents it couldn't decrypted. It will also decrypt the document.
+Add an one-time event-handler. It behaves like [hoodie-store-client's one](https://github.com/hoodiehq/hoodie-store-client#storeone). But will not emit events for not encrypted documents or documents it couldn't decrypted. It will also decrypt the document.
 
 Argument| Type  | Description      | Required
 --------|-------|------------------|----------

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,7 +58,7 @@ Those concepts/rules apply to all methods.
 
 **Everything of a doc will get encrypted. Except for `_id`, `_rev`, `_deleted`, `_attachments`, `_conflicts` and the `hoodie` object!**
 
-Also optionally _all keys that start with an underscore (\_) will not get encrypted_! Because they are __special document members__ used by CouchDB and PouchDB! To deactivated this set the *plugin option* `notHandleSpecialDocumentMembers` to `true`.
+Also _all keys that start with an underscore (\_) will not get encrypted_! Because they are __special document members__ used by CouchDB and PouchDB! To deactivated this set the *plugin option* `notHandleSpecialDocumentMembers` to `true`.
 
 **Don't save private data in the `_id`**!
 
@@ -206,7 +206,7 @@ A salt is a string that will get used with the password together for the encrypt
 
 __*This will not unlock the cryptoStore!*__
 
-Rejects if there is already a local or remote `hoodiePluginCryptoStore/salt` or `_design/cryptoStore/salt` doc!
+Rejects if there is already a local or remote `hoodiePluginCryptoStore/salt` doc!
 
 Rejects with:
 
@@ -259,7 +259,7 @@ A salt is a string that will get used with the password together for the encrypt
 
 __*This will not unlock the cryptoStore!*__
 
-Rejects if there is already a local or remote `hoodiePluginCryptoStore/salt` or `_design/cryptoStore/salt` doc!
+Rejects if there is already a local or remote `hoodiePluginCryptoStore/salt` doc!
 
 Rejects with:
 
@@ -303,9 +303,9 @@ Argument | Type   | Description                           | Required
 ---------|--------|---------------------------------------|----------
 `password` | String | The password used for encrypting the objects | Yes
 
-Uses the salt in `hoodiePluginCryptoStore/salt` or `_design/cryptoStore/salt` and unlocks the cryptoStore.
-It will pull `hoodiePluginCryptoStore/salt` and `_design/cryptoStore/salt` from the remote and
-reject if they don't exists or got deleted or the password mismatch.
+Uses the salt in `hoodiePluginCryptoStore/salt` and unlocks the cryptoStore.
+It will pull `hoodiePluginCryptoStore/salt` from the remote and
+reject if it doesn't exists or got deleted or the password mismatch.
 
 Rejects with:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,7 +58,7 @@ Those concepts/rules apply to all methods.
 
 **Everything of a doc will get encrypted. Except for `_id`, `_rev`, `_deleted`, `_attachments`, `_conflicts` and the `hoodie` object!**
 
-Also optionally _all keys that start with an underscore (\_) will not get encrypted_! Because they are __special document members__ used by CouchDB and PouchDB! For now you must opt into this by setting the option `handleSpecialDocumentMembers` to `true`. **But it _will_ become the _default_!**
+Also optionally _all keys that start with an underscore (\_) will not get encrypted_! Because they are __special document members__ used by CouchDB and PouchDB! To deactivated this set the *plugin option* `notHandleSpecialDocumentMembers` to `true`.
 
 **Don't save private data in the `_id`**!
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -138,7 +138,7 @@ var hoodie = new Hoodie({ // create an instance of the hoodie-client
 cryptoStore(hoodie, { handleSpecialDocumentMembers: true }) // sets up hoodie.cryptoStore
 ```
 
-**In a future update this will become the default!**
+[**Version 3 did change handling of special document members!**](#handling-special-document-members-is-now-the-default)
 
 ## v3 Update Notes
 
@@ -160,13 +160,15 @@ hoodie.store.remove('_design/cryptoStore/salt')
 
 A future major version will no longer add a missing password check and fail!
 
-Please don't set `noPasswordCheckAutoFix` to `true` and/or have your *users change their password*.
+Please have your *users change their password* or/and don't set `noPasswordCheckAutoFix` to `true`.
+
+You are all set, if all your users `hoodiePluginCryptoStore/salt` doc contain a `check`-field!
 
 ### Dropping of support for node v6
 
 Because Node version 6 is end-of-life, it is now no longer supported!
 
-If you are still using node v6: please migrate to a newer version! Node version 8 will also be end-of-life at the end of this year.
+If you are still using node v6: please migrate to a newer version! Node version 8 will also be end-of-life by the end of this year.
 
 ### Handling special document members is now the default
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -10,6 +10,7 @@ It will list all changes, you have to make, if you update to:
 - [v2](#v2-update-notes)
 - [v2.2](#v22-update-notes)
 - [v2.3](#v23-update-notes)
+- [v3](#v3-update-notes)
 
 ## v2 Update Notes
 
@@ -95,7 +96,7 @@ __If the user was already setup, then no reset key will get generated, until the
 
 ## v2.3 Update Notes
 
-Bigging from v2.3 you can mark document-members to be not encrypted! They will get saved in plain text!
+Beginning from v2.3 you can mark document-members to be not encrypted! They will get saved in plain text!
 
 This is useful for example if you wand to put in place a search or document relationship.
 
@@ -138,3 +139,37 @@ cryptoStore(hoodie, { handleSpecialDocumentMembers: true }) // sets up hoodie.cr
 ```
 
 **In a future update this will become the default!**
+
+## v3 Update Notes
+
+### Old salt doc
+
+The old salt doc (`_design/cryptoStore/salt`) is now ignored!
+
+If an user still has the old salt doc, then you can move it to `hoodiePluginCryptoStore/salt`.
+
+```javascript
+const salt = await hoodie.store.find('_design/cryptoStore/salt')
+salt._id = `hoodiePluginCryptoStore/salt`
+delete salt._rev
+hoodie.store.add(salt)
+hoodie.store.remove('_design/cryptoStore/salt')
+```
+
+### Salt doc without a password check is deprecated
+
+A future major version will no longer add a missing password check and fail!
+
+Please don't set `noPasswordCheckAutoFix` to `true` and/or have your *users change their password*.
+
+### Dropping of support for node v6
+
+Because Node version 6 is end-of-life, it is now no longer supported!
+
+If you are still using node v6: please migrate to a newer version! Node version 8 will also be end-of-life at the end of this year.
+
+### Handling special document members is now the default
+
+All document members/fields that start with an `_` will now not encrypted.
+
+To deactivate it set the option `notHandleSpecialDocumentMembers` to `true`.

--- a/hoodie/client.js
+++ b/hoodie/client.js
@@ -20,7 +20,7 @@ function cryptoStore (hoodie, options) {
       withIdPrefixStore[prefix] = hoodie.store.withIdPrefix(prefix)
       return withIdPrefixStore[prefix]
     },
-    handleSpecialMembers: options != null && Boolean(options.handleSpecialDocumentMembers),
+    handleSpecialMembers: options == null || !options.notHandleSpecialDocumentMembers,
     noPasswordCheckAutoFix: options != null && Boolean(options.noPasswordCheckAutoFix)
   }
 

--- a/hoodie/client.js
+++ b/hoodie/client.js
@@ -24,6 +24,14 @@ function cryptoStore (hoodie, options) {
     noPasswordCheckAutoFix: options != null && Boolean(options.noPasswordCheckAutoFix)
   }
 
+  if (state.noPasswordCheckAutoFix) {
+    console.warn(
+      'Salt doc without a password check is deprecated!\n\n' +
+      'Read more at https://github.com/Terreii/hoodie-plugin-store-crypto/' +
+      'blob/latest/docs/update.md#v3-update-notes'
+    )
+  }
+
   var handler = {
     on: hoodie.store.on,
     once: hoodie.store.one,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -35,18 +35,15 @@ function setup (store, state, password, salt) {
     ))
   }
 
-  return store.find(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+  return store.find(['hoodiePluginCryptoStore/salt'])
 
     .then(function (obj) {
       // check if a salt doc already exists
-      if (
-        (obj[0].status !== 404 && !obj[0]._deleted) ||
-        (obj[1].status !== 404 && !obj[1]._deleted)
-      ) {
+      if (obj[0].status !== 404 && !obj[0]._deleted) {
         throw pouchdbErrors.UNAUTHORIZED
       }
 
-      return store.pull(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+      return store.pull(['hoodiePluginCryptoStore/salt'])
 
         .catch(function (error) {
           console.warn("Couldn't pull docs from remote. Creating new salt!\nError: " + error)
@@ -56,10 +53,7 @@ function setup (store, state, password, salt) {
 
     .then(function (obj) {
       // // check if a salt doc already exists on remoteDb
-      if (obj.length > 0 && (
-        (obj[0].status !== 404 && !obj[0]._deleted) ||
-        (obj.length === 2 && obj[1].status !== 404 && !obj[1]._deleted)
-      )) {
+      if (obj.length > 0 && (obj[0].status !== 404 && !obj[0]._deleted)) {
         throw pouchdbErrors.UNAUTHORIZED
       }
 

--- a/lib/unlock.js
+++ b/lib/unlock.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var pouchdbErrors = require('pouchdb-errors')
-var assign = require('lodash/assign')
 var Promise = require('lie')
 var decrypt = require('native-crypto/decrypt')
 
@@ -37,14 +36,14 @@ function unlock (store, state, password) {
   }
 
   // get updated salt docs from remote
-  return store.pull(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+  return store.pull(['hoodiePluginCryptoStore/salt'])
 
     .then(
       function () {
-        return store.find(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+        return store.find(['hoodiePluginCryptoStore/salt'])
       },
       function (error) {
-        return store.find(['hoodiePluginCryptoStore/salt', '_design/cryptoStore/salt'])
+        return store.find(['hoodiePluginCryptoStore/salt'])
 
           .then(function (result) {
             console.warn("Couldn't pull salt-docs from remote. Using local salt!\nError: " + error)
@@ -54,28 +53,15 @@ function unlock (store, state, password) {
     )
 
     .then(function (objects) {
-      // if the old salt doc exists: delete it
-      if (objects[1].status !== 404 && !objects[1]._deleted) {
-        store.remove(objects[1])
-      }
-
       if (typeof objects[0].salt === 'string' && !objects[0]._deleted) {
         // if salt doc exists
         return objects[0]
       } else if (
         (typeof objects[0].salt === 'string' && objects[0]._deleted) ||
-        (objects[0].status === 404 && objects[1].status === 404)
+        objects[0].status === 404
       ) {
-        // if no salt doc (new and old) exists
+        // if no salt doc exists
         throw pouchdbErrors.MISSING_DOC
-      } else if (objects[0].status === 404 && objects[1].status == null) {
-        // move old salt doc to new
-        return store.add(assign({}, objects[1], {
-          _id: 'hoodiePluginCryptoStore/salt',
-          _rev: null,
-          _deleted: null,
-          hoodie: {}
-        }))
       } else {
         return objects[0]
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "End-to-end crypto plugin for the Hoodie client store.",
   "main": "index.js",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
@@ -50,7 +50,7 @@
     "pouchdb-adapter-memory": "^7.1.1",
     "pouchdb-core": "^7.1.1",
     "pouchdb-replication": "^7.1.1",
-    "semantic-release": "^15.13.27",
+    "semantic-release": "^15.13.28",
     "standard": "^14.3.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.11.0",

--- a/tests/integration/add.js
+++ b/tests/integration/add.js
@@ -216,60 +216,39 @@ test("cryptoStore.add() shouldn't encrypt fields in cy_ignore and __cy_ignore", 
     .catch(t.end)
 })
 
-test("cryptoStore.add() doesn't encrypt fields starting with _ if option is set", function (t) {
+test("cryptoStore.add() shouldn't encrypt fields starting with _", async t => {
   t.plan(3)
 
-  var hoodie = createCryptoStore({ handleSpecialDocumentMembers: true })
-  var hoodie2 = createCryptoStore()
+  const hoodie = createCryptoStore()
+  const hoodie2 = createCryptoStore({ notHandleSpecialDocumentMembers: true })
 
-  hoodie.cryptoStore.setup('test')
-
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
+    await hoodie.cryptoStore.add({
+      value: 42,
+      _other: 'test value'
     })
+    t.fail(new Error('should have thrown with doc_validation'))
+  } catch (err) {
+    t.is(err.name, 'doc_validation', 'value with _ was passed on')
+  }
 
-    .then(function () {
-      return hoodie.cryptoStore.add({
-        value: 42,
-        _other: 'test value'
-      })
+  try {
+    await hoodie2.cryptoStore.setup('test')
+    await hoodie2.cryptoStore.unlock('test')
+
+    const obj = await hoodie2.cryptoStore.add({
+      value: 42,
+      _other: 'test value'
     })
+    t.is(obj._other, 'test value', 'members with _ are added')
 
-    .then(
-      function (obj) {
-        t.fail(new Error('should have thrown with doc_validation'))
-      },
-      function (err) {
-        t.is(err.name, 'doc_validation', 'value with _ was passed on')
-      }
-    )
-
-    .then(function () {
-      return hoodie2.cryptoStore.setup('test')
-    })
-
-    .then(function () {
-      return hoodie2.cryptoStore.unlock('test')
-    })
-
-    .then(function () {
-      return hoodie2.cryptoStore.add({
-        value: 42,
-        _other: 'test value'
-      })
-    })
-
-    .then(function (obj) {
-      t.is(obj._other, 'test value', 'members with _ are added')
-
-      return hoodie2.store.find(obj._id)
-    })
-
-    .then(function (obj) {
-      t.is(obj._other, undefined, 'member with _ was encrypted')
-    })
-
-    .catch(t.end)
+    const encrypted = await hoodie2.store.find(obj._id)
+    t.is(encrypted._other, undefined, 'member with _ was encrypted')
+  } catch (err) {
+    t.end(err)
+  }
 })
 
 test('cryptoStore.add() should throw if plugin isn\'t unlocked', function (t) {

--- a/tests/integration/plugin.js
+++ b/tests/integration/plugin.js
@@ -6,7 +6,7 @@ var cryptoStore = require('../../')
 var PouchDB = require('../utils/pouchdb.js')
 var uniqueName = require('../utils/unique-name')
 
-test('cryptoStore should listen to account/signout events', function (t) {
+test('cryptoStore should listen to account/signout events', t => {
   t.plan(3)
 
   var name = uniqueName()
@@ -33,7 +33,7 @@ test('cryptoStore should listen to account/signout events', function (t) {
   }
 })
 
-test('cryptoStore should work with a not complete Hoodie-client', function (t) {
+test('cryptoStore should work with a not complete Hoodie-client', t => {
   t.plan(1)
 
   var name = uniqueName()
@@ -55,15 +55,45 @@ test('cryptoStore should work with a not complete Hoodie-client', function (t) {
   }
 })
 
+test('cryptoStore does not encrypt fields starting with _', async t => {
+  t.plan(1)
+
+  var name = uniqueName()
+
+  var hoodie = {
+    account: { on: function () {} },
+    store: new Store(name, {
+      PouchDB: PouchDB,
+      remote: 'remote-' + name
+    })
+  }
+
+  cryptoStore(hoodie)
+
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
+
+    await hoodie.cryptoStore.add({
+      value: 42,
+      _other: 'public'
+    })
+
+    t.fail(new Error('should have thrown with doc_validation'))
+  } catch (err) {
+    t.is(err.name, 'doc_validation', 'value with _ was passed on')
+  }
+})
+
 test(
-  'cryptoStore does not encrypt fields starting with _ if handleSpecialDocumentMembers' +
-    ' is set to true',
-  function (t) {
-    t.plan(1)
+  'cryptoStore does encrypt fields starting with _ if notHandleSpecialDocumentMembers is ' +
+  'set to true',
+  async t => {
+    t.plan(2)
 
-    var name = uniqueName()
+    const name = uniqueName()
 
-    var hoodie = {
+    const hoodie = {
       account: { on: function () {} },
       store: new Store(name, {
         PouchDB: PouchDB,
@@ -71,28 +101,22 @@ test(
       })
     }
 
-    cryptoStore(hoodie, { handleSpecialDocumentMembers: true })
+    cryptoStore(hoodie, { notHandleSpecialDocumentMembers: true })
 
-    hoodie.cryptoStore.setup('test')
+    try {
+      await hoodie.cryptoStore.setup('test')
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
+      const doc = await hoodie.cryptoStore.add({
+        value: 42,
+        _other: 'not public'
       })
+      t.is(doc._other, 'not public', 'member starting with _ was encrypted')
 
-      .then(function () {
-        return hoodie.cryptoStore.add({
-          value: 42,
-          _other: 'public'
-        })
-      })
-
-      .then(
-        function (obj) {
-          t.fail(new Error('should have thrown with doc_validation'))
-        },
-        function (err) {
-          t.is(err.name, 'doc_validation', 'value with _ was passed on')
-        }
-      )
+      const encryptedDoc = await hoodie.store.find(doc._id)
+      t.is(encryptedDoc._other, undefined, 'member starting with _ is not public')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )

--- a/tests/integration/remove-all.js
+++ b/tests/integration/remove-all.js
@@ -302,97 +302,75 @@ test("cryptoStore.removeAll() shouldn't encrypt fields in cy_ignore and __cy_ign
   })
 })
 
-test(
-  "cryptoStore.removeAll() shouldn't encrypt fields starting with _ if option is set",
-  function (t) {
-    t.plan(6)
+test("cryptoStore.removeAll() shouldn't encrypt fields starting with _", async t => {
+  t.plan(6)
 
-    var hoodie = createCryptoStore({ handleSpecialDocumentMembers: true })
-    var hoodie2 = createCryptoStore()
+  const hoodie = createCryptoStore()
+  const hoodie2 = createCryptoStore({ notHandleSpecialDocumentMembers: true })
 
-    hoodie.cryptoStore.setup('test')
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
-
-      .then(function () {
-        return hoodie.cryptoStore.add([
-          {
-            _id: 'a',
-            value: 42,
-            _other: 'test value'
-          },
-          {
-            _id: 'b',
-            _value: 42,
-            other: 'test value'
-          }
-        ])
-      })
-
-      .then(function () {
-        return hoodie.cryptoStore.removeAll()
-      })
-
-      .then(
-        function (objects) {
-          t.ok(objects instanceof Error, 'Update should have failed')
-          t.fail('Update should have failed')
-        },
-        function (err) {
-          t.ok(err instanceof Error, 'Update did fail')
-          t.is(err.name, 'doc_validation', 'value with _ was passed on')
-        }
-      )
-
-      .then(function () {
-        return hoodie2.cryptoStore.setup('test')
-      })
-
-      .then(function () {
-        return hoodie2.cryptoStore.unlock('test')
-      })
-
-      .then(function () {
-        return hoodie2.cryptoStore.add([
-          {
-            _id: 'a',
-            value: 42,
-            _other: 'test value'
-          },
-          {
-            _id: 'b',
-            _value: 42,
-            other: 'test value'
-          }
-        ])
-      })
-
-      .then(function () {
-        return hoodie2.cryptoStore.removeAll()
-      })
-
-      .catch(t.end)
-
-    hoodie2.store.on('remove', function (obj) {
-      switch (obj._id) {
-        case 'a':
-          t.is(obj.value, undefined, 'values still get encrypted')
-          t.is(obj._other, undefined, 'values starting with _ are encrypted')
-          break
-
-        case 'b':
-          t.is(obj.other, undefined, 'values still get encrypted')
-          t.is(obj._value, undefined, 'values starting with _ are encrypted')
-          break
-
-        default:
-          t.fail('unknown id')
+    await hoodie.cryptoStore.add([
+      {
+        _id: 'a',
+        value: 42,
+        _other: 'test value'
+      },
+      {
+        _id: 'b',
+        _value: 42,
+        other: 'test value'
       }
-    })
+    ])
+
+    const objects = await hoodie.cryptoStore.removeAll()
+    t.ok(objects instanceof Error, 'Update should have failed')
+    t.fail('Update should have failed')
+  } catch (err) {
+    t.ok(err instanceof Error, 'Update did fail')
+    t.is(err.name, 'doc_validation', 'value with _ was passed on')
   }
-)
+
+  hoodie2.store.on('remove', obj => {
+    switch (obj._id) {
+      case 'a':
+        t.is(obj.value, undefined, 'values still get encrypted')
+        t.is(obj._other, undefined, 'values starting with _ are encrypted')
+        break
+
+      case 'b':
+        t.is(obj.other, undefined, 'values still get encrypted')
+        t.is(obj._value, undefined, 'values starting with _ are encrypted')
+        break
+
+      default:
+        t.fail('unknown id')
+    }
+  })
+
+  try {
+    await hoodie2.cryptoStore.setup('test')
+    await hoodie2.cryptoStore.unlock('test')
+
+    await hoodie2.cryptoStore.add([
+      {
+        _id: 'a',
+        value: 42,
+        _other: 'test value'
+      },
+      {
+        _id: 'b',
+        _value: 42,
+        other: 'test value'
+      }
+    ])
+    await hoodie2.cryptoStore.removeAll()
+  } catch (err) {
+    t.end(err)
+  }
+})
 
 test('cryptoStore.removeAll() should throw if plugin isn\'t unlocked', function (t) {
   t.plan(4)

--- a/tests/integration/remove.js
+++ b/tests/integration/remove.js
@@ -460,69 +460,44 @@ test("cryptoStore.remove() shouldn't encrypt fields in cy_ignore and __cy_ignore
   })
 })
 
-test("cryptoStore.remove() doesn't encrypt fields starting with _ if option is set", function (t) {
+test("cryptoStore.remove() shouldn't encrypt fields starting with _", async t => {
   t.plan(4)
 
-  var hoodie = createCryptoStore({ handleSpecialDocumentMembers: true })
-  var hoodie2 = createCryptoStore()
+  const hoodie = createCryptoStore()
+  const hoodie2 = createCryptoStore({ notHandleSpecialDocumentMembers: true })
 
-  hoodie.cryptoStore.setup('test')
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
 
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
+    const obj = await hoodie.cryptoStore.add({ value: 42 })
+
+    await hoodie.cryptoStore.remove(obj._id, {
+      _other: 'test value'
     })
+    t.fail(new Error('should have thrown with doc_validation'))
+  } catch (err) {
+    t.is(err.name, 'doc_validation', 'value with _ was passed on')
+  }
 
-    .then(function () {
-      return hoodie.cryptoStore.add({
-        value: 42
-      })
-    })
-
-    .then(function (obj) {
-      return hoodie.cryptoStore.remove(obj._id, {
-        _other: 'test value'
-      })
-    })
-
-    .then(
-      function (obj) {
-        t.fail(new Error('should have thrown with doc_validation'))
-      },
-      function (err) {
-        t.is(err.name, 'doc_validation', 'value with _ was passed on')
-      }
-    )
-
-    .then(function () {
-      return hoodie2.cryptoStore.setup('test')
-    })
-
-    .then(function () {
-      return hoodie2.cryptoStore.unlock('test')
-    })
-
-    .then(function () {
-      return hoodie2.cryptoStore.add({
-        value: 42
-      })
-    })
-
-    .then(function (obj) {
-      return hoodie2.cryptoStore.remove(obj._id, {
-        _other: 'test value'
-      })
-    })
-
-    .then(function (obj) {
-      t.is(obj._other, 'test value', 'values starting with _ are added')
-    })
-
-    .catch(t.end)
-
-  hoodie2.store.on('remove', function (obj) {
+  hoodie2.store.on('remove', obj => {
     t.is(obj.value, undefined, 'members still get encrypted')
     t.is(obj._other, undefined, 'members starting with _ are encrypted')
   })
+
+  try {
+    await hoodie2.cryptoStore.setup('test')
+    await hoodie2.cryptoStore.unlock('test')
+
+    const obj = await hoodie2.cryptoStore.add({ value: 42 })
+
+    const updated = await hoodie2.cryptoStore.remove(obj._id, {
+      _other: 'test value'
+    })
+    t.is(updated._other, 'test value', 'values starting with _ are added')
+  } catch (err) {
+    t.end(err)
+  }
 })
 
 test('cryptoStore.remove() should throw if plugin isn\'t unlocked', function (t) {

--- a/tests/integration/unlock.js
+++ b/tests/integration/unlock.js
@@ -1,92 +1,55 @@
 'use strict'
 
-var test = require('tape')
-var Store = require('@hoodie/store-client')
-var pouchdbErrors = require('pouchdb-errors')
+const test = require('tape')
+const Store = require('@hoodie/store-client')
+const pouchdbErrors = require('pouchdb-errors')
 
-var cryptoStore = require('../../')
+const cryptoStore = require('../../')
 
-var createCryptoStore = require('../utils/createCryptoStore')
-var PouchDB = require('../utils/pouchdb.js')
-var uniqueName = require('../utils/unique-name')
+const createCryptoStore = require('../utils/createCryptoStore')
+const PouchDB = require('../utils/pouchdb.js')
+const uniqueName = require('../utils/unique-name')
 
-test('cryptoStore.unlock(password) should use the saved salt', function (t) {
+test('cryptoStore.unlock(password) should use the saved salt', async t => {
   t.plan(1)
 
-  var hoodie = createCryptoStore()
+  const hoodie = createCryptoStore()
 
-  hoodie.store.add({
-    _id: 'hoodiePluginCryptoStore/salt',
-    salt: 'bf11fa9bafca73586e103d60898989d4',
-    check: {
-      nonce: '6e9cf8a4a6eee26f19ff8c70',
-      tag: '0d2cfd645fe49b8a29ce22dbbac26b1e',
-      data: '5481cf42b7e3f1d15477ed8f1d938bd9fd6103903be6dd4e146f69d9f124e34f33b7fa66930557ae6c88' +
-        '2cc5f0e23ac4450a8a6653d5aa36ba531667b9cc6874fddf995efc50322bd1bfed19eb086a2efc7732c7cb6f' +
-        '56efd6efe33d273f3e6f538a17d183bc1e9f160d0c080f25a17b863e6904fd0a1c8fd918a3bb79655fb1'
-    }
-  })
-
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
+  try {
+    await hoodie.store.add({
+      _id: 'hoodiePluginCryptoStore/salt',
+      salt: 'bf11fa9bafca73586e103d60898989d4',
+      check: {
+        nonce: '6e9cf8a4a6eee26f19ff8c70',
+        tag: '0d2cfd645fe49b8a29ce22dbbac26b1e',
+        data: '5481cf42b7e3f1d15477ed8f1d938bd9fd6103903be6dd4e146f69d9f124e34f33b7fa669305' +
+          '57ae6c882cc5f0e23ac4450a8a6653d5aa36ba531667b9cc6874fddf995efc50322bd1bfed19eb086a2ef' +
+          'c7732c7cb6f56efd6efe33d273f3e6f538a17d183bc1e9f160d0c080f25a17b863e6904fd0a1c8' +
+          'fd918a3bb79655fb1'
+      }
     })
 
-    .then(function () {
-      t.pass('does unlock, and not fail')
-    })
-
-    .catch(function (err) {
-      t.end(err)
-    })
-})
-
-test('cryptoStore.unlock(password) move and use old salt doc', function (t) {
-  t.plan(2)
-
-  var hoodie = createCryptoStore()
-
-  hoodie.store.add({
-    _id: '_design/cryptoStore/salt',
-    salt: 'bf11fa9bafca73586e103d60898989d4'
-  })
-
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
-    })
-
-    .then(function () {
-      return hoodie.store.find('_design/cryptoStore/salt')
-    })
-
-    .catch(function (err) {
-      t.equal(err.status, 404, 'old doc is deleted')
-
-      return hoodie.store.find('hoodiePluginCryptoStore/salt')
-    })
-
-    .then(function (doc) {
-      t.equal(doc.salt, 'bf11fa9bafca73586e103d60898989d4', 'new salt doc has same salt')
-    })
-
-    .catch(function (err) {
-      t.end(err)
-    })
+    await hoodie.cryptoStore.unlock('test')
+    t.pass('does unlock, and not fail')
+  } catch (err) {
+    t.end(err)
+  }
 })
 
 test(
   "cryptoStore.unlock(password) should try to pull the salt doc from remote if it doesn't exist",
-  function (t) {
+  async t => {
     t.plan(1)
 
-    var name = uniqueName()
-    var remoteDbName = 'remote-' + name
-    var remoteDb = new PouchDB(remoteDbName)
-    var store = new Store(name, {
+    const name = uniqueName()
+    const remoteDbName = 'remote-' + name
+    const remoteDb = new PouchDB(remoteDbName)
+    const store = new Store(name, {
       PouchDB: PouchDB,
       remote: remoteDb
     })
 
-    var hoodie = {
+    const hoodie = {
       account: {
         on: function () {}
       },
@@ -94,51 +57,45 @@ test(
     }
     cryptoStore(hoodie)
 
-    remoteDb.put({
-      _id: '_design/cryptoStore/salt',
-      salt: 'bf11fa9bafca73586e103d60898989d4',
-      hoodie: {
-        createdAt: new Date().toJSON()
-      },
-      check: {
-        nonce: '6e9cf8a4a6eee26f19ff8c70',
-        tag: '0d2cfd645fe49b8a29ce22dbbac26b1e',
-        data: '5481cf42b7e3f1d15477ed8f1d938bd9fd6103903be6dd4e146f69d9f124e34f33b7fa66930557ae6c' +
-          '882cc5f0e23ac4450a8a6653d5aa36ba531667b9cc6874fddf995efc50322bd1bfed19eb086a2efc7732c7' +
-          'cb6f56efd6efe33d273f3e6f538a17d183bc1e9f160d0c080f25a17b863e6904fd0a1c8fd918a3bb79655fb1'
-      }
-    })
-
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
+    try {
+      await remoteDb.put({
+        _id: 'hoodiePluginCryptoStore/salt',
+        salt: 'bf11fa9bafca73586e103d60898989d4',
+        hoodie: {
+          createdAt: new Date().toJSON()
+        },
+        check: {
+          nonce: '6e9cf8a4a6eee26f19ff8c70',
+          tag: '0d2cfd645fe49b8a29ce22dbbac26b1e',
+          data: '5481cf42b7e3f1d15477ed8f1d938bd9fd6103903be6dd4e146f69d9f124e34f33b7fa669' +
+            '30557ae6c882cc5f0e23ac4450a8a6653d5aa36ba531667b9cc6874fddf995efc50322bd1bfed' +
+            '19eb086a2efc7732c7cb6f56efd6efe33d273f3e6f538a17d183bc1e9f160d0c080f25a17b863' +
+            'e6904fd0a1c8fd918a3bb79655fb1'
+        }
       })
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function (doc) {
-        t.equal(doc.salt, 'bf11fa9bafca73586e103d60898989d4', 'salt doc was pulled')
-      })
-
-      .catch(function (err) {
-        t.fail(err)
-      })
+      const doc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.equal(doc.salt, 'bf11fa9bafca73586e103d60898989d4', 'salt doc was pulled')
+    } catch (err) {
+      t.fail(err)
+    }
   }
 )
 
-test('cryptoStore.unlock(password) should fail if local and remote have no salt doc', function (t) {
+test('cryptoStore.unlock(password) should fail if local and remote have no salt doc', async t => {
   t.plan(1)
 
-  var name = uniqueName()
-  var remoteDbName = 'remote-' + name
-  var remoteDb = new PouchDB(remoteDbName)
-  var store = new Store(name, {
+  const name = uniqueName()
+  const remoteDbName = 'remote-' + name
+  const remoteDb = new PouchDB(remoteDbName)
+  const store = new Store(name, {
     PouchDB: PouchDB,
     remote: remoteDb
   })
 
-  var hoodie = {
+  const hoodie = {
     account: {
       on: function () {}
     },
@@ -146,599 +103,481 @@ test('cryptoStore.unlock(password) should fail if local and remote have no salt 
   }
   cryptoStore(hoodie)
 
-  hoodie.cryptoStore.unlock('test')
-
-    .then(function () {
-      t.fail("setUp didn't fail")
-    })
-
-    .catch(function (err) {
-      t.equal(err.name, pouchdbErrors.MISSING_DOC.name, 'fails with PouchDB unauthorized error')
-    })
+  try {
+    await hoodie.cryptoStore.unlock('test')
+    t.fail("setUp didn't fail")
+  } catch (err) {
+    t.equal(err.name, pouchdbErrors.MISSING_DOC.name, 'fails with PouchDBs missing doc error')
+  }
 })
 
-test('cryptoStore.unlock(password) should fail if the salt is not a 32 char string', function (t) {
-  t.plan(2)
+test('cryptoStore.unlock(password) should ignore the old salt doc', async t => {
+  t.plan(1)
 
-  var hoodie = createCryptoStore()
+  const hoodie = createCryptoStore()
 
-  hoodie.store.add({
-    _id: '_design/cryptoStore/salt',
-    salt: 'bf11fa9bafca73586e103d60898989'
-  })
-
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
+  try {
+    await hoodie.store.add({
+      _id: '_design/cryptoStore/salt',
+      salt: 'bf11fa9bafca73586e103d60898989d4'
     })
 
-    .then(
-      function () {
-        t.fail('unlock didn\'t fail')
+    await hoodie.cryptoStore.unlock('test')
+    t.fail('it should have ignored the old salt doc!')
+  } catch (err) {
+    t.equal(err.name, pouchdbErrors.MISSING_DOC.name, 'fails with PouchDBs missing doc error')
+  }
+})
+
+test('cryptoStore.unlock(password) should fail if the salt is not a 32 char string', async t => {
+  t.plan(2)
+
+  const hoodie = createCryptoStore()
+
+  try {
+    await hoodie.store.add({
+      _id: 'hoodiePluginCryptoStore/salt',
+      salt: 'bf11fa9bafca73586e103d60898989',
+      hoodie: {
+        createdAt: new Date().toJSON()
       },
-      function (err) {
-        t.equal(err.status, pouchdbErrors.BAD_ARG.status)
-        t.equal(err.reason, 'salt in "hoodiePluginCryptoStore/salt" must be a 32 char string!')
+      check: {
+        nonce: '6e9cf8a4a6eee26f19ff8c70',
+        tag: '0d2cfd645fe49b8a29ce22dbbac26b1e',
+        data: '5481cf42b7e3f1d15477ed8f1d938bd9fd6103903be6dd4e146f69d9f124e34f33b7fa669' +
+          '30557ae6c882cc5f0e23ac4450a8a6653d5aa36ba531667b9cc6874fddf995efc50322bd1bfed' +
+          '19eb086a2efc7732c7cb6f56efd6efe33d273f3e6f538a17d183bc1e9f160d0c080f25a17b863' +
+          'e6904fd0a1c8fd918a3bb79655fb1'
       }
-    )
+    })
+
+    await hoodie.cryptoStore.unlock('test')
+
+    t.fail('unlock didn\'t fail')
+  } catch (err) {
+    t.equal(err.status, pouchdbErrors.BAD_ARG.status)
+    t.equal(err.reason, 'salt in "hoodiePluginCryptoStore/salt" must be a 32 char string!')
+  }
 })
 
 test(
   'cryptoStore.unlock(password) should fail if the encrypted check for the password fails',
-  function (t) {
+  async t => {
     t.plan(1)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add({
-      _id: 'hoodiePluginCryptoStore/salt',
-      salt: '5a352fb087036f59242316e1aab1d681',
-      check: {
-        nonce: '3829ae61881defa450655a43',
-        tag: '8f73c2e364c64a6601b8c6bdabaf2dd3',
-        data: '9a32bbead59b32adb99b54483e4ea34c7731f90df1eed76c867b77c60c393891d660f6cad9433fd437' +
-          '7ad938cf9912139a9f79bfe85d4f144f4a887722571bdeeab25e63b831abc115f61fe4954ceee7d3968656' +
-          '43e246048ab6fb1295495a6b55fb53fbfe590cbf7bbec604a1d76259dab0f0c4628c52b25c0ece6412930445'
-      }
-    })
-
-      .then(function () {
-        return hoodie.cryptoStore.unlock('other-Password')
+    try {
+      await hoodie.store.add({
+        _id: 'hoodiePluginCryptoStore/salt',
+        salt: '5a352fb087036f59242316e1aab1d681',
+        check: {
+          nonce: '3829ae61881defa450655a43',
+          tag: '8f73c2e364c64a6601b8c6bdabaf2dd3',
+          data: '9a32bbead59b32adb99b54483e4ea34c7731f90df1eed76c867b77c60c393891d660f' +
+            '6cad9433fd4377ad938cf9912139a9f79bfe85d4f144f4a887722571bdeeab25e63b831ab' +
+            'c115f61fe4954ceee7d396865643e246048ab6fb1295495a6b55fb53fbfe590cbf7bbec60' +
+            '4a1d76259dab0f0c4628c52b25c0ece6412930445'
+        }
       })
+      await hoodie.cryptoStore.unlock('other-Password')
 
-      .then(function () {
-        t.fail('unlock should have failed')
-      })
-
-      .catch(function (err) {
-        t.equal(err.status, pouchdbErrors.UNAUTHORIZED.status, 'should be UNAUTHORIZED')
-      })
+      t.fail('unlock should have failed')
+    } catch (err) {
+      t.equal(err.status, pouchdbErrors.UNAUTHORIZED.status, 'should be UNAUTHORIZED')
+    }
   }
 )
 
-test('cryptoStore.unlock(password) should fail if it did already unlock', function (t) {
+test('cryptoStore.unlock(password) should fail if it did already unlock', async t => {
   t.plan(2)
 
-  var hoodie = createCryptoStore()
+  const hoodie = createCryptoStore()
 
-  hoodie.cryptoStore.setup('test')
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
+    await hoodie.cryptoStore.unlock('test')
 
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
-    })
-
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
-    })
-
-    .then(
-      function () {
-        t.fail('unlock should have failed on second unlock')
-      },
-      function (err) {
-        t.equal(err.status, pouchdbErrors.INVALID_REQUEST.status, 'shoud be an INVALID_REQUEST')
-        t.equal(err.reason, 'store is already unlocked!', 'With the correct error message')
-      }
-    )
+    t.fail('unlock should have failed on second unlock')
+  } catch (err) {
+    t.equal(err.status, pouchdbErrors.INVALID_REQUEST.status, 'should be an INVALID_REQUEST')
+    t.equal(err.reason, 'store is already unlocked!', 'With the correct error message')
+  }
 })
 
 test(
-  'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
+  'cryptoStore.unlock(password) should add checks to salt doc after first encrypted doc' +
     ' was read with find',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.find('test-doc')
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.find('test-doc')
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with findAll',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      await hoodie.cryptoStore.unlock('test')
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.findAll()
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.findAll()
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with findOrAdd',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.findOrAdd('test-doc', { otherValue: 2 })
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.findOrAdd('test-doc', { otherValue: 2 })
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with update',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.update('test-doc', { otherValue: 2 })
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.update('test-doc', { otherValue: 2 })
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with updateOrAdd',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.updateOrAdd('test-doc', { otherValue: 2 })
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.updateOrAdd('test-doc', { otherValue: 2 })
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with updateAll',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.updateAll({ otherValue: 2 })
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.updateAll({ otherValue: 2 })
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with remove',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.remove('test-doc', { otherValue: 2 })
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.remove('test-doc', { otherValue: 2 })
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should add checks to moved old salt doc after first encrypted doc' +
     ' was read with removeAll',
-  function (t) {
+  async t => {
     t.plan(4)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.removeAll({ otherValue: 2 })
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.removeAll({ otherValue: 2 })
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.ok(saltDoc.check.tag.length === 32, 'tag part should have a length of 32')
-        t.ok(saltDoc.check.data.length > 0, 'encrypted data')
-        t.ok(saltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.ok(updatedSaltDoc.check.tag.length === 32, 'tag part should have a length of 32')
+      t.ok(updatedSaltDoc.check.data.length > 0, 'encrypted data')
+      t.ok(updatedSaltDoc.check.nonce.length === 24, 'nonce should have a length of 24')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.withPassword() should not case a check to be added to the moved saltDoc',
-  function (t) {
+  async t => {
     t.plan(1)
 
-    var hoodie = createCryptoStore()
+    const hoodie = createCryptoStore()
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: 'b2917d9e4e2954bef59ce09a0805b05c',
-        data: '4ff14f46992d2f473288ef',
-        nonce: '49c61c84248eb6c0e6cda510'
-      }
-    ])
+    try {
+      await hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: 'b2917d9e4e2954bef59ce09a0805b05c',
+          data: '4ff14f46992d2f473288ef',
+          nonce: '49c61c84248eb6c0e6cda510'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const { store } = await hoodie.cryptoStore.withPassword(
+        'other',
+        '495d3b6a06b27512b47bc426150866b3'
+      )
 
-      .then(function () {
-        return hoodie.cryptoStore.withPassword('other', '495d3b6a06b27512b47bc426150866b3')
-      })
+      await store.find('test-doc')
 
-      .then(function (result) {
-        return result.store.find('test-doc')
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
+    } catch (err) {
+      t.end(err)
+    }
   }
 )
 
 test(
   'cryptoStore.unlock(password) should not add checks if the option "noPasswordAutoFix" was set',
-  function (t) {
+  async t => {
     t.plan(2)
 
-    var hoodie = createCryptoStore({ noPasswordCheckAutoFix: true })
+    const hoodie = createCryptoStore({ noPasswordCheckAutoFix: true })
 
-    hoodie.store.add([
-      {
-        _id: '_design/cryptoStore/salt',
-        salt: 'bf11fa9bafca73586e103d60898989d4'
-      },
-      {
-        _id: 'test-doc',
-        tag: '1d9fb919ebecfe3c207781d103164a7f',
-        data: 'e6dc77a9451e3c91113ba19ead4c4045',
-        nonce: 'e1cb5518678d08619697d6f7'
-      }
-    ])
+    try {
+      hoodie.store.add([
+        {
+          _id: 'hoodiePluginCryptoStore/salt',
+          salt: 'bf11fa9bafca73586e103d60898989d4'
+        },
+        {
+          _id: 'test-doc',
+          tag: '1d9fb919ebecfe3c207781d103164a7f',
+          data: 'e6dc77a9451e3c91113ba19ead4c4045',
+          nonce: 'e1cb5518678d08619697d6f7'
+        }
+      ])
+      await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+      const saltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
 
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
+      await hoodie.cryptoStore.find('test-doc')
 
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-
-        return hoodie.cryptoStore.find('test-doc')
-      })
-
-      .then(function () {
-        return hoodie.store.find('hoodiePluginCryptoStore/salt')
-      })
-
-      .then(function (saltDoc) {
-        t.notOk(saltDoc.check, 'salt doc shouldn\'t have the check object')
-      })
-
-      .catch(function (err) {
-        t.end(err)
-      })
+      const updatedSaltDoc = await hoodie.store.find('hoodiePluginCryptoStore/salt')
+      t.notOk(updatedSaltDoc.check, "salt doc shouldn't have the check object")
+    } catch (err) {
+      t.end(err)
+    }
   }
 )

--- a/tests/integration/update-all.js
+++ b/tests/integration/update-all.js
@@ -357,92 +357,67 @@ test("cryptoStore.updateAll() shouldn't encrypt fields in cy_ignore and __cy_ign
     .catch(t.end)
 })
 
-test(
-  "cryptoStore.updateAll() doesn't encrypt fields starting with _ if option is set",
-  function (t) {
-    t.plan(6)
+test("cryptoStore.updateAll() shouldn't encrypt fields starting with _", async t => {
+  t.plan(6)
 
-    var hoodie = createCryptoStore({ handleSpecialDocumentMembers: true })
-    var hoodie2 = createCryptoStore()
+  const hoodie = createCryptoStore()
+  const hoodie2 = createCryptoStore({ notHandleSpecialDocumentMembers: true })
 
-    hoodie.cryptoStore.setup('test')
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
 
-      .then(function () {
-        return hoodie.cryptoStore.unlock('test')
-      })
+    await hoodie.cryptoStore.add([
+      {
+        _id: 'a',
+        value: 42
+      },
+      {
+        _id: 'b',
+        other: 'not public'
+      }
+    ])
 
-      .then(function () {
-        return hoodie.cryptoStore.add([
-          {
-            _id: 'a',
-            value: 42
-          },
-          {
-            _id: 'b',
-            other: 'not public'
-          }
-        ])
-      })
+    const objects = await hoodie.cryptoStore.updateAll({
+      _other: 'test value'
+    })
 
-      .then(function () {
-        return hoodie.cryptoStore.updateAll({
-          _other: 'test value'
-        })
-      })
-
-      .then(
-        function (objects) {
-          t.ok(objects instanceof Error, 'Update should have failed')
-          t.fail('Update should have failed')
-        },
-        function (err) {
-          t.ok(err instanceof Error, 'Update did fail')
-          t.is(err.name, 'doc_validation', 'value with _ was passed on')
-        }
-      )
-
-      .then(function () {
-        return hoodie2.cryptoStore.setup('test')
-      })
-
-      .then(function () {
-        return hoodie2.cryptoStore.unlock('test')
-      })
-
-      .then(function () {
-        return hoodie2.cryptoStore.add([
-          {
-            _id: 'a',
-            value: 42
-          },
-          {
-            _id: 'b',
-            other: 'not public'
-          }
-        ])
-      })
-
-      .then(function () {
-        return hoodie2.cryptoStore.updateAll({
-          _other: 'test value'
-        })
-      })
-
-      .then(function () {
-        return hoodie2.store.findAll()
-      })
-
-      .then(function (objects) {
-        t.is(objects[0].value, undefined, 'values still get encrypted')
-        t.is(objects[0]._other, undefined, 'members starting with _ are encrypted')
-
-        t.is(objects[1].other, undefined, 'values still get encrypted')
-        t.is(objects[1]._value, undefined, 'members starting with _ are encrypted')
-      })
-
-      .catch(t.end)
+    t.ok(objects instanceof Error, 'Update should have failed')
+    t.fail('Update should have failed')
+  } catch (err) {
+    t.ok(err instanceof Error, 'Update did fail')
+    t.is(err.name, 'doc_validation', 'value with _ was passed on')
   }
-)
+
+  try {
+    await hoodie2.cryptoStore.setup('test')
+    await hoodie2.cryptoStore.unlock('test')
+
+    await hoodie2.cryptoStore.add([
+      {
+        _id: 'a',
+        value: 42
+      },
+      {
+        _id: 'b',
+        other: 'not public'
+      }
+    ])
+
+    await hoodie2.cryptoStore.updateAll({
+      _other: 'test value'
+    })
+
+    const objects = await hoodie2.store.findAll()
+    t.is(objects[0].value, undefined, 'values still get encrypted')
+    t.is(objects[0]._other, undefined, 'members starting with _ are encrypted')
+
+    t.is(objects[1].other, undefined, 'values still get encrypted')
+    t.is(objects[1]._value, undefined, 'members starting with _ are encrypted')
+  } catch (err) {
+    t.end(err)
+  }
+})
 
 test('cryptoStore.updateAll() should throw if plugin isn\'t unlocked', function (t) {
   t.plan(4)

--- a/tests/integration/update.js
+++ b/tests/integration/update.js
@@ -606,71 +606,42 @@ test("cryptoStore.update() shouldn't encrypt fields in cy_ignore and __cy_ignore
     .catch(t.end)
 })
 
-test("cryptoStore.update() doesn't encrypt fields starting with _ if option is set", function (t) {
+test("cryptoStore.update() shouldn't encrypt fields starting with _", async t => {
   t.plan(4)
 
-  var hoodie = createCryptoStore({ handleSpecialDocumentMembers: true })
-  var hoodie2 = createCryptoStore()
+  const hoodie = createCryptoStore()
+  const hoodie2 = createCryptoStore({ notHandleSpecialDocumentMembers: true })
 
-  hoodie.cryptoStore.setup('test')
+  try {
+    await hoodie.cryptoStore.setup('test')
+    await hoodie.cryptoStore.unlock('test')
 
-    .then(function () {
-      return hoodie.cryptoStore.unlock('test')
+    const obj = await hoodie.cryptoStore.add({ value: 42 })
+    await hoodie.cryptoStore.update(obj._id, {
+      _other: 'test value'
     })
 
-    .then(function () {
-      return hoodie.cryptoStore.add({
-        value: 42
-      })
+    t.fail(new Error('should have thrown with doc_validation'))
+  } catch (err) {
+    t.is(err.name, 'doc_validation', 'value with _ was passed on')
+  }
+
+  try {
+    await hoodie2.cryptoStore.setup('test')
+    await hoodie2.cryptoStore.unlock('test')
+
+    const obj = await hoodie2.cryptoStore.add({ value: 42 })
+    const updated = await hoodie2.cryptoStore.update(obj._id, {
+      _other: 'test value'
     })
+    t.is(updated._other, 'test value', 'members with _ are added')
 
-    .then(function (obj) {
-      return hoodie.cryptoStore.update(obj._id, {
-        _other: 'test value'
-      })
-    })
-
-    .then(
-      function (obj) {
-        t.fail(new Error('should have thrown with doc_validation'))
-      },
-      function (err) {
-        t.is(err.name, 'doc_validation', 'value with _ was passed on')
-      }
-    )
-
-    .then(function () {
-      return hoodie2.cryptoStore.setup('test')
-    })
-
-    .then(function () {
-      return hoodie2.cryptoStore.unlock('test')
-    })
-
-    .then(function () {
-      return hoodie2.cryptoStore.add({
-        value: 42
-      })
-    })
-
-    .then(function (obj) {
-      return hoodie2.cryptoStore.update(obj._id, {
-        _other: 'test value'
-      })
-    })
-
-    .then(function (obj) {
-      t.is(obj._other, 'test value', 'members with _ are added')
-
-      return hoodie2.store.find(obj._id)
-    })
-
-    .then(function (obj) {
-      t.is(obj.value, undefined, 'members still get encrypted')
-      t.is(obj._other, undefined, 'members starting with _ are encrypted')
-    })
-
-    .catch(t.end)
+    const encrypted = await hoodie2.store.find(updated._id)
+    t.is(encrypted.value, undefined, 'members still get encrypted')
+    t.is(encrypted._other, undefined, 'members starting with _ are encrypted')
+  } catch (err) {
+    t.end(err)
+  }
 })
 
 test('cryptoStore.update() should throw if plugin isn\'t unlocked', function (t) {


### PR DESCRIPTION
Fixes #86.

Changes proposed in this pull request:

- Drop support for __node v6__ (#70)
- Remove handling of old salt doc (`_design/cryptoStore/salt`)
- Default to not encrypt special document members (fields with an _id that start with `_`)
