### PR TITLE
Insecure origins

### DIFF
--- a/lib/create-key.js
+++ b/lib/create-key.js
@@ -1,6 +1,7 @@
 'use strict'
 
-var pbkdf2 = require('native-crypto/pbkdf2')
+var pbkdf2 = require('pbkdf2')
+var Promise = require('lie')
 var randomBytes = require('randombytes')
 
 module.exports = function createKey (password, saltArg) {
@@ -10,12 +11,18 @@ module.exports = function createKey (password, saltArg) {
     ? saltArg
     : randomBytes(16).toString('hex')
 
-  return pbkdf2(password, Buffer.from(salt, 'hex'), iterations, 256 / 8, digest)
+  return new Promise(function (resolve, reject) {
+    var saltyBuffy = Buffer.from(salt, 'hex')
 
-    .then(function (key) {
-      return {
-        key: key,
-        salt: salt
+    pbkdf2.pbkdf2(password, saltyBuffy, iterations, 256 / 8, digest, function (err, key) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve({
+          key: key,
+          salt: salt
+        })
       }
     })
+  })
 }

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -3,7 +3,6 @@
 var encrypt = require('native-crypto/encrypt')
 var randomBytes = require('randombytes')
 var uuid = require('uuid').v4
-var keys = require('lodash/keys')
 var includes = require('lodash/includes')
 
 var ignore = require('./utils/ignore.js')
@@ -28,7 +27,7 @@ function encryptDoc (state, doc, prefix) {
     Array.isArray(doc.__cy_ignore) ? doc.__cy_ignore : []
   )
 
-  keys(doc).forEach(function (key) {
+  Object.getOwnPropertyNames(doc).forEach(function (key) {
     if (doc[key] === undefined || key === '__cy_ignore') return
 
     if ((state.handleSpecialMembers && key.charAt(0) === '_') || includes(docIgnore, key)) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -40,7 +40,7 @@ function setup (store, state, password, salt) {
     .then(function (obj) {
       // check if a salt doc already exists
       if (obj[0].status !== 404 && !obj[0]._deleted) {
-        throw pouchdbErrors.UNAUTHORIZED
+        throw pouchdbErrors.createError(pouchdbErrors.UNAUTHORIZED, 'salt doc already exist!')
       }
 
       return store.pull(['hoodiePluginCryptoStore/salt'])
@@ -52,9 +52,12 @@ function setup (store, state, password, salt) {
     })
 
     .then(function (obj) {
-      // // check if a salt doc already exists on remoteDb
+      // check if a salt doc already exists on remoteDb
       if (obj.length > 0 && (obj[0].status !== 404 && !obj[0]._deleted)) {
-        throw pouchdbErrors.UNAUTHORIZED
+        throw pouchdbErrors.createError(
+          pouchdbErrors.UNAUTHORIZED,
+          'salt doc already exist on the remote DB!'
+        )
       }
 
       return salt != null

--- a/lib/unlock.js
+++ b/lib/unlock.js
@@ -103,8 +103,13 @@ function unlock (store, state, password) {
               return res
             })
 
-            .catch(function () {
-              throw pouchdbErrors.UNAUTHORIZED
+            .catch(function (err) {
+              // attach PouchDBs UNAUTHORIZED error to the error
+              err.status = pouchdbErrors.UNAUTHORIZED.status
+              err.name = pouchdbErrors.UNAUTHORIZED.name
+              err.reason = pouchdbErrors.UNAUTHORIZED.reason
+              err.error = true
+              throw err
             })
         })
     })

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pouchdb-adapter-memory": "^7.1.1",
     "pouchdb-core": "^7.1.1",
     "pouchdb-replication": "^7.1.1",
-    "semantic-release": "^15.13.30",
+    "semantic-release": "^15.13.31",
     "standard": "^14.3.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.11.0",
@@ -66,6 +66,7 @@
     "lie": "^3.3.0",
     "lodash": "^4.17.15",
     "native-crypto": "^1.8.1",
+    "pbkdf2": "^3.0.17",
     "pouchdb-errors": "^7.1.1",
     "randombytes": "^2.1.0",
     "uuid": "^3.2.1"


### PR DESCRIPTION
Fixes #69.

Changes proposed in this pull request:

- Use [browserify's pbkdf2](https://github.com/crypto-browserify/pbkdf2) to also be able to generate a key on insecure origins when using chrome.

Reviewer: @Terreii
