### PR TITLE
Puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,17 @@
     "lib"
   ],
   "devDependencies": {
+    "browserify": "^16.5.0",
     "hoodie": "^28.2.10",
     "pouchdb-adapter-memory": "^7.1.1",
     "pouchdb-core": "^7.1.1",
     "pouchdb-replication": "^7.1.1",
+    "puppeteer": "^2.0.0",
+    "puppeteer-firefox": "^0.5.0",
     "semantic-release": "^15.13.31",
     "standard": "^14.3.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
+    "tape": "^4.12.0",
     "textlint": "^11.5.0",
     "textlint-rule-alex": "^1.3.1",
     "textlint-rule-common-misspellings": "^1.0.1",

--- a/tests/unit/create-key-test.js
+++ b/tests/unit/create-key-test.js
@@ -87,3 +87,49 @@ test('create a key in Firefox', async t => {
     t.end(err)
   }
 })
+
+test('create a key and salt if no salt was passed in chrome', async t => {
+  t.plan(2)
+
+  try {
+    const result = await browserTest('chrome', './lib/create-key', 'createKey', () => {
+      const test = async () => {
+        const result = await createKey('test')
+        return {
+          key: result.key.toString('hex'),
+          salt: result.salt
+        }
+      }
+      return test()
+    })
+
+    t.ok(result.key.length > 0, 'generated key')
+
+    t.ok(result.salt.length === 32, 'generated salt')
+  } catch (err) {
+    t.end(err)
+  }
+})
+
+test('create a key and salt if no salt was passed in firefox', async t => {
+  t.plan(2)
+
+  try {
+    const result = await browserTest('firefox', './lib/create-key', 'createKey', () => {
+      const test = async () => {
+        const result = await createKey('test')
+        return {
+          key: result.key.toString('hex'),
+          salt: result.salt
+        }
+      }
+      return test()
+    })
+
+    t.ok(result.key.length > 0, 'generated key')
+
+    t.ok(result.salt.length === 32, 'generated salt')
+  } catch (err) {
+    t.end(err)
+  }
+})

--- a/tests/unit/create-key-test.js
+++ b/tests/unit/create-key-test.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const test = require('tape')
-const browserify = require('browserify')
-const puppeteerChrome = require('puppeteer')
-const puppeteerFirefox = require('puppeteer-firefox')
 
 const createKey = require('../../lib/create-key')
+
+const browserTest = require('../utils/browser-test')
 
 test('create a key', async t => {
   t.plan(2)
@@ -38,27 +37,8 @@ test('create a key and salt if no salt was passed', async t => {
 test('create a key in chrome', async t => {
   t.plan(2)
 
-  const browser = await puppeteerChrome.launch()
-
   try {
-    const browserifyInstance = browserify('./lib/create-key', {
-      standalone: 'createKey'
-    })
-
-    const scriptContent = await new Promise((resolve, reject) => {
-      const stream = browserifyInstance.bundle()
-
-      let scriptContent = ''
-      stream.on('data', chunk => { scriptContent += chunk })
-
-      stream.on('end', () => { resolve(scriptContent) })
-      stream.on('error', reject)
-    })
-
-    const page = await browser.newPage()
-    await page.addScriptTag({ content: scriptContent })
-
-    const keyResult = await page.evaluate(() => {
+    const keyResult = await browserTest('chrome', './lib/create-key', 'createKey', () => {
       const test = async () => {
         const result = await createKey('test', 'bf11fa9bafca73586e103d60898989d4')
         return {
@@ -78,35 +58,14 @@ test('create a key in chrome', async t => {
     t.is(keyResult.salt, 'bf11fa9bafca73586e103d60898989d4', 'returned salt')
   } catch (err) {
     t.end(err)
-  } finally {
-    await browser.close()
   }
 })
 
 test('create a key in Firefox', async t => {
   t.plan(2)
 
-  const browser = await puppeteerFirefox.launch()
-
   try {
-    const browserifyInstance = browserify('./lib/create-key', {
-      standalone: 'createKey'
-    })
-
-    const scriptContent = await new Promise((resolve, reject) => {
-      const stream = browserifyInstance.bundle()
-
-      let scriptContent = ''
-      stream.on('data', chunk => { scriptContent += chunk })
-
-      stream.on('end', () => { resolve(scriptContent) })
-      stream.on('error', reject)
-    })
-
-    const page = await browser.newPage()
-    await page.addScriptTag({ content: scriptContent })
-
-    const keyResult = await page.evaluate(() => {
+    const keyResult = await browserTest('firefox', './lib/create-key', 'createKey', () => {
       const test = async () => {
         const result = await createKey('test', 'bf11fa9bafca73586e103d60898989d4')
         return {
@@ -126,7 +85,5 @@ test('create a key in Firefox', async t => {
     t.is(keyResult.salt, 'bf11fa9bafca73586e103d60898989d4', 'returned salt')
   } catch (err) {
     t.end(err)
-  } finally {
-    await browser.close()
   }
 })

--- a/tests/unit/create-key-test.js
+++ b/tests/unit/create-key-test.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const test = require('tape')
+const browserify = require('browserify')
+const puppeteerChrome = require('puppeteer')
+const puppeteerFirefox = require('puppeteer-firefox')
 
 const createKey = require('../../lib/create-key')
 
@@ -30,4 +33,100 @@ test('create a key and salt if no salt was passed', async t => {
   t.ok(result.key.length > 0, 'generated key')
 
   t.ok(result.salt.length === 32, 'generated salt')
+})
+
+test('create a key in chrome', async t => {
+  t.plan(2)
+
+  const browser = await puppeteerChrome.launch()
+
+  try {
+    const browserifyInstance = browserify('./lib/create-key', {
+      standalone: 'createKey'
+    })
+
+    const scriptContent = await new Promise((resolve, reject) => {
+      const stream = browserifyInstance.bundle()
+
+      let scriptContent = ''
+      stream.on('data', chunk => { scriptContent += chunk })
+
+      stream.on('end', () => { resolve(scriptContent) })
+      stream.on('error', reject)
+    })
+
+    const page = await browser.newPage()
+    await page.addScriptTag({ content: scriptContent })
+
+    const keyResult = await page.evaluate(() => {
+      const test = async () => {
+        const result = await createKey('test', 'bf11fa9bafca73586e103d60898989d4')
+        return {
+          key: result.key.toString('hex'),
+          salt: result.salt
+        }
+      }
+      return test()
+    })
+
+    t.is(
+      keyResult.key,
+      '8ecab44b2448d6bae235476a134be8f6bec705a35a02dea3afb4e648f29eb66c',
+      'generated key from password "test" with salt "bf11fa9bafca73586e103d60898989d4"'
+    )
+
+    t.is(keyResult.salt, 'bf11fa9bafca73586e103d60898989d4', 'returned salt')
+  } catch (err) {
+    t.end(err)
+  } finally {
+    await browser.close()
+  }
+})
+
+test('create a key in Firefox', async t => {
+  t.plan(2)
+
+  const browser = await puppeteerFirefox.launch()
+
+  try {
+    const browserifyInstance = browserify('./lib/create-key', {
+      standalone: 'createKey'
+    })
+
+    const scriptContent = await new Promise((resolve, reject) => {
+      const stream = browserifyInstance.bundle()
+
+      let scriptContent = ''
+      stream.on('data', chunk => { scriptContent += chunk })
+
+      stream.on('end', () => { resolve(scriptContent) })
+      stream.on('error', reject)
+    })
+
+    const page = await browser.newPage()
+    await page.addScriptTag({ content: scriptContent })
+
+    const keyResult = await page.evaluate(() => {
+      const test = async () => {
+        const result = await createKey('test', 'bf11fa9bafca73586e103d60898989d4')
+        return {
+          key: result.key.toString('hex'),
+          salt: result.salt
+        }
+      }
+      return test()
+    })
+
+    t.is(
+      keyResult.key,
+      '8ecab44b2448d6bae235476a134be8f6bec705a35a02dea3afb4e648f29eb66c',
+      'generated key from password "test" with salt "bf11fa9bafca73586e103d60898989d4"'
+    )
+
+    t.is(keyResult.salt, 'bf11fa9bafca73586e103d60898989d4', 'returned salt')
+  } catch (err) {
+    t.end(err)
+  } finally {
+    await browser.close()
+  }
 })

--- a/tests/unit/decrypt-test.js
+++ b/tests/unit/decrypt-test.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const test = require('tape')
+const browserify = require('browserify')
+const puppeteerChrome = require('puppeteer')
+const puppeteerFirefox = require('puppeteer-firefox')
 
 const decrypt = require('../../lib/decrypt')
 
@@ -130,5 +133,125 @@ test('decrypt merges all not encrypted fields into the result object', async t =
     }, 'decrypted and merged doc with overwritten field')
   } catch (err) {
     t.end(err)
+  }
+})
+
+test('encrypt should work in chrome', async t => {
+  t.plan(1)
+
+  const browser = await puppeteerChrome.launch()
+
+  try {
+    const browserifyInstance = browserify('./lib/decrypt', {
+      standalone: 'decrypt'
+    })
+
+    const scriptContent = await new Promise((resolve, reject) => {
+      const stream = browserifyInstance.bundle()
+
+      let scriptContent = ''
+      stream.on('data', chunk => { scriptContent += chunk })
+
+      stream.on('end', () => { resolve(scriptContent) })
+      stream.on('error', reject)
+    })
+
+    const page = await browser.newPage()
+    await page.addScriptTag({ content: scriptContent })
+
+    const decryptedDoc = await page.evaluate(() => {
+      const doc = {
+        _id: 'hello',
+        _rev: '1-1234567890',
+        hoodie: {
+          createdAt: '2019-12-18T23:12:43.568Z'
+        },
+        tag: '6bc503f508a88e67f82aaf76406ac509',
+        data: '1b16dfd5903880851103599e801b07ae915db7194f52d36b321b91bd822c232ade9572b39e',
+        nonce: '433d5b039fbda3b75b0a7f56'
+      }
+
+      const key = new Uint8Array(
+        '8ecab44b2448d6bae235476a134be8f6bec705a35a02dea3afb4e648f29eb66c'
+          .match(/.{1,2}/g)
+          .map(byte => parseInt(byte, 16))
+      )
+      return decrypt(key, doc)
+    })
+
+    t.deepEqual(decryptedDoc, {
+      _id: 'hello',
+      _rev: '1-1234567890',
+      hoodie: {
+        createdAt: '2019-12-18T23:12:43.568Z'
+      },
+      foo: 'bar',
+      hello: 'world',
+      day: 1
+    }, 'decrypted doc')
+  } catch (err) {
+    t.end(err)
+  } finally {
+    await browser.close()
+  }
+})
+
+test('encrypt should work in Firefox', async t => {
+  t.plan(1)
+
+  const browser = await puppeteerFirefox.launch()
+
+  try {
+    const browserifyInstance = browserify('./lib/decrypt', {
+      standalone: 'decrypt'
+    })
+
+    const scriptContent = await new Promise((resolve, reject) => {
+      const stream = browserifyInstance.bundle()
+
+      let scriptContent = ''
+      stream.on('data', chunk => { scriptContent += chunk })
+
+      stream.on('end', () => { resolve(scriptContent) })
+      stream.on('error', reject)
+    })
+
+    const page = await browser.newPage()
+    await page.addScriptTag({ content: scriptContent })
+
+    const decryptedDoc = await page.evaluate(() => {
+      const doc = {
+        _id: 'hello',
+        _rev: '1-1234567890',
+        hoodie: {
+          createdAt: '2019-12-18T23:12:43.568Z'
+        },
+        tag: '6bc503f508a88e67f82aaf76406ac509',
+        data: '1b16dfd5903880851103599e801b07ae915db7194f52d36b321b91bd822c232ade9572b39e',
+        nonce: '433d5b039fbda3b75b0a7f56'
+      }
+
+      const key = new Uint8Array(
+        '8ecab44b2448d6bae235476a134be8f6bec705a35a02dea3afb4e648f29eb66c'
+          .match(/.{1,2}/g)
+          .map(byte => parseInt(byte, 16))
+      )
+      return decrypt(key, doc)
+    })
+
+    t.deepEqual(decryptedDoc, {
+      _id: 'hello',
+      _rev: '1-1234567890',
+      hoodie: {
+        createdAt: '2019-12-18T23:12:43.568Z'
+      },
+      foo: 'bar',
+      hello: 'world',
+      day: 1
+    }, 'decrypted doc')
+  } catch (err) {
+    t.end(err)
+  } finally {
+    await browser.close()
   }
 })

--- a/tests/unit/decrypt-test.js
+++ b/tests/unit/decrypt-test.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const test = require('tape')
-const browserify = require('browserify')
-const puppeteerChrome = require('puppeteer')
-const puppeteerFirefox = require('puppeteer-firefox')
 
 const decrypt = require('../../lib/decrypt')
+
+const browserTest = require('../utils/browser-test')
 
 test('encrypt should encrypt a document', async t => {
   t.plan(1)
@@ -136,30 +135,11 @@ test('decrypt merges all not encrypted fields into the result object', async t =
   }
 })
 
-test('encrypt should work in chrome', async t => {
+test('decrypt should work in chrome', async t => {
   t.plan(1)
 
-  const browser = await puppeteerChrome.launch()
-
   try {
-    const browserifyInstance = browserify('./lib/decrypt', {
-      standalone: 'decrypt'
-    })
-
-    const scriptContent = await new Promise((resolve, reject) => {
-      const stream = browserifyInstance.bundle()
-
-      let scriptContent = ''
-      stream.on('data', chunk => { scriptContent += chunk })
-
-      stream.on('end', () => { resolve(scriptContent) })
-      stream.on('error', reject)
-    })
-
-    const page = await browser.newPage()
-    await page.addScriptTag({ content: scriptContent })
-
-    const decryptedDoc = await page.evaluate(() => {
+    const decryptedDoc = await browserTest('chrome', './lib/decrypt', 'decrypt', () => {
       const doc = {
         _id: 'hello',
         _rev: '1-1234567890',
@@ -191,35 +171,14 @@ test('encrypt should work in chrome', async t => {
     }, 'decrypted doc')
   } catch (err) {
     t.end(err)
-  } finally {
-    await browser.close()
   }
 })
 
-test('encrypt should work in Firefox', async t => {
+test('decrypt should work in Firefox', async t => {
   t.plan(1)
 
-  const browser = await puppeteerFirefox.launch()
-
   try {
-    const browserifyInstance = browserify('./lib/decrypt', {
-      standalone: 'decrypt'
-    })
-
-    const scriptContent = await new Promise((resolve, reject) => {
-      const stream = browserifyInstance.bundle()
-
-      let scriptContent = ''
-      stream.on('data', chunk => { scriptContent += chunk })
-
-      stream.on('end', () => { resolve(scriptContent) })
-      stream.on('error', reject)
-    })
-
-    const page = await browser.newPage()
-    await page.addScriptTag({ content: scriptContent })
-
-    const decryptedDoc = await page.evaluate(() => {
+    const decryptedDoc = await browserTest('chrome', './lib/decrypt', 'decrypt', () => {
       const doc = {
         _id: 'hello',
         _rev: '1-1234567890',
@@ -251,7 +210,5 @@ test('encrypt should work in Firefox', async t => {
     }, 'decrypted doc')
   } catch (err) {
     t.end(err)
-  } finally {
-    await browser.close()
   }
 })

--- a/tests/unit/encrypt-test.js
+++ b/tests/unit/encrypt-test.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const test = require('tape')
-const browserify = require('browserify')
-const puppeteerChrome = require('puppeteer')
-const puppeteerFirefox = require('puppeteer-firefox')
 
 const encrypt = require('../../lib/encrypt')
+
+const browserTest = require('../utils/browser-test')
 
 test('encrypt should encrypt a document', async t => {
   t.plan(6)
@@ -247,27 +246,8 @@ test(
 test('encryption works in chrome', async t => {
   t.plan(9)
 
-  const browser = await puppeteerChrome.launch()
-
   try {
-    const browserifyInstance = browserify('./lib/encrypt', {
-      standalone: 'encrypt'
-    })
-
-    const scriptContent = await new Promise((resolve, reject) => {
-      const stream = browserifyInstance.bundle()
-
-      let scriptContent = ''
-      stream.on('data', chunk => { scriptContent += chunk })
-
-      stream.on('end', () => { resolve(scriptContent) })
-      stream.on('error', reject)
-    })
-
-    const page = await browser.newPage()
-    await page.addScriptTag({ content: scriptContent })
-
-    const encryptedDoc = await page.evaluate(() => {
+    const encryptedDoc = await browserTest('chrome', './lib/encrypt', 'encrypt', () => {
       const doc = {
         _id: 'hello',
         _rev: '1-1234567890',
@@ -301,35 +281,14 @@ test('encryption works in chrome', async t => {
     t.is(encryptedDoc.day, undefined, "day doesn't exist")
   } catch (err) {
     t.end(err)
-  } finally {
-    await browser.close()
   }
 })
 
 test('encryption works in Firefox', async t => {
   t.plan(9)
 
-  const browser = await puppeteerFirefox.launch()
-
   try {
-    const browserifyInstance = browserify('./lib/encrypt', {
-      standalone: 'encrypt'
-    })
-
-    const scriptContent = await new Promise((resolve, reject) => {
-      const stream = browserifyInstance.bundle()
-
-      let scriptContent = ''
-      stream.on('data', chunk => { scriptContent += chunk })
-
-      stream.on('end', () => { resolve(scriptContent) })
-      stream.on('error', reject)
-    })
-
-    const page = await browser.newPage()
-    await page.addScriptTag({ content: scriptContent })
-
-    const encryptedDoc = await page.evaluate(() => {
+    const encryptedDoc = await browserTest('firefox', './lib/encrypt', 'encrypt', () => {
       const doc = {
         _id: 'hello',
         _rev: '1-1234567890',
@@ -363,7 +322,5 @@ test('encryption works in Firefox', async t => {
     t.is(encryptedDoc.day, undefined, "day doesn't exist")
   } catch (err) {
     t.end(err)
-  } finally {
-    await browser.close()
   }
 })

--- a/tests/unit/encrypt-test.js
+++ b/tests/unit/encrypt-test.js
@@ -263,6 +263,7 @@ test('encryption works in chrome', async t => {
       stream.on('end', () => { resolve(scriptContent) })
       stream.on('error', reject)
     })
+
     const page = await browser.newPage()
     await page.addScriptTag({ content: scriptContent })
 
@@ -324,6 +325,7 @@ test('encryption works in Firefox', async t => {
       stream.on('end', () => { resolve(scriptContent) })
       stream.on('error', reject)
     })
+
     const page = await browser.newPage()
     await page.addScriptTag({ content: scriptContent })
 

--- a/tests/utils/browser-test.js
+++ b/tests/utils/browser-test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+module.exports = browserTest
+
+const browserify = require('browserify')
+const puppeteerChrome = require('puppeteer')
+const puppeteerFirefox = require('puppeteer-firefox')
+
+const browsers = {
+  chrome: puppeteerChrome,
+  firefox: puppeteerFirefox
+}
+
+/**
+ * Run a test in a browser and returns the result of the test function.
+ * @param {'chrome'|'firefox'} browserName Name of the browser that should be used for this test.
+ * @param {string} modulePath Path of the to testing module. Relative to the project directory.
+ * @param {string} exportName Name used for the export of the module.
+ * @param {function} fn Test function. This function will be run in the browser.
+ */
+async function browserTest (browserName, modulePath, exportName, fn) {
+  const browser = await browsers[browserName].launch()
+
+  try {
+    const browserifyInstance = browserify(modulePath, {
+      standalone: exportName
+    })
+
+    const scriptContent = await new Promise((resolve, reject) => {
+      const stream = browserifyInstance.bundle()
+
+      let scriptContent = ''
+      stream.on('data', chunk => { scriptContent += chunk })
+
+      stream.on('end', () => { resolve(scriptContent) })
+      stream.on('error', reject)
+    })
+
+    const page = await browser.newPage()
+    await page.addScriptTag({ content: scriptContent })
+
+    const result = await page.evaluate(fn)
+
+    await browser.close()
+
+    return result
+  } catch (err) {
+    await browser.close()
+    throw err
+  }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- Install `browserify`, `puppeteer` and `puppeteer-firefox`
- Add tests for generating a **key**, **encryption** and **decryption** in **Chrome** and **Firefox**.

Reviewer: @Terreii
