### PR TITLE
use browserify-aes

### DIFF
--- a/lib/decrypt.js
+++ b/lib/decrypt.js
@@ -2,10 +2,10 @@
 
 module.exports = decryptDoc
 
-var aes = require('browserify-aes')
 var assign = require('lodash/assign')
 var Promise = require('lie')
 
+var decrypt = require('./helpers/decrypt-core')
 var isEncryptedObject = require('./utils/is-encrypted-object')
 
 var cryptoKeys = [
@@ -13,7 +13,6 @@ var cryptoKeys = [
   'tag',
   'nonce'
 ]
-var subtle = global.crypto && global.crypto.subtle
 
 // Mostly copied from https://github.com/calvinmetcalf/crypto-pouch/blob/master/index.js#L157
 function decryptDoc (key, doc) {
@@ -29,40 +28,7 @@ function decryptDoc (key, doc) {
   var nonce = Buffer.from(doc.nonce, 'hex')
   var aad = Buffer.from(doc._id)
 
-  return checkBrowser()
-
-    // Original implementation from:
-    // https://github.com/calvinmetcalf/native-crypto/blob/master/browser/decrypt.js
-    .then(function (supportsBrowserCrypto) {
-      // for when the browser supports crypto.subtle
-      if (supportsBrowserCrypto) {
-        return subtle.importKey('raw', key, { name: 'AES-GCM' }, true, ['decrypt'])
-
-          .then(function (cryptoKey) {
-            var options = {
-              name: 'AES-GCM',
-              iv: nonce,
-              additionalData: aad
-            }
-
-            var encryptedData = Buffer.concat([data, tag])
-            return subtle.decrypt(options, cryptoKey, encryptedData)
-          })
-
-          .then(function (result) {
-            return Buffer.from(result).toString()
-          })
-      } else {
-        // fall back to browserify-aes
-        var cipher = aes.createDecipheriv('aes-256-gcm', key, nonce)
-        cipher.setAAD(aad)
-        cipher.setAuthTag(tag)
-
-        var output = cipher.update(data)
-        cipher.final()
-        return output.toString()
-      }
-    })
+  return decrypt(key, nonce, data, tag, aad)
 
     .then(function (outData) {
       var decrypted = JSON.parse(outData)
@@ -76,51 +42,5 @@ function decryptDoc (key, doc) {
       })
 
       return out
-    })
-}
-
-var canUseBrowserCrypto = null
-
-function checkBrowser () {
-  if (global.process && !global.process.browser) {
-    return Promise.resolve(false)
-  }
-  if (!subtle || !subtle.importKey || !subtle.encrypt) {
-    return Promise.resolve(false)
-  }
-  if (canUseBrowserCrypto != null) {
-    return Promise.resolve(canUseBrowserCrypto)
-  }
-
-  var zeroBuffy = Buffer.alloc(16, 0)
-
-  return subtle.importKey('raw', zeroBuffy, { name: 'AES-GCM' }, true, ['decrypt'])
-
-    .then(function (key) {
-      return subtle.decrypt(
-        {
-          name: 'AES-GCM',
-          iv: zeroBuffy.slice(0, 12),
-          additionalData: zeroBuffy.slice(0, 8)
-        },
-        key,
-        Buffer.from(
-          'A4jazmC2o5LzKMK5cbL+ePeVqqtJS1kj9/2J/5SLweAgAhEhTnOU2iCJtqzQk6vgyU2iGRG' +
-            'OKX17fry8ycOI8p7MWbwdPpusE+GvoYsO2TE=',
-          'base64'
-        )
-      )
-    })
-
-    .then(function (result) {
-      canUseBrowserCrypto = Buffer.from(result).toString('base64') ===
-        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
-
-      return canUseBrowserCrypto
-    })
-
-    .catch(function () {
-      canUseBrowserCrypto = false
-      return canUseBrowserCrypto
     })
 }

--- a/lib/decrypt.js
+++ b/lib/decrypt.js
@@ -1,18 +1,19 @@
 'use strict'
 
+module.exports = decryptDoc
+
+var assign = require('lodash/assign')
 var decrypt = require('native-crypto/decrypt')
 var Promise = require('lie')
-var assign = require('lodash/assign')
 
 var isEncryptedObject = require('./utils/is-encrypted-object')
-
-module.exports = decryptDoc
 
 var cryptoKeys = [
   'data',
   'tag',
   'nonce'
 ]
+var subtle = global.crypto && global.crypto.subtle
 
 // Mostly copied from https://github.com/calvinmetcalf/crypto-pouch/blob/master/index.js#L157
 function decryptDoc (key, doc) {
@@ -25,7 +26,11 @@ function decryptDoc (key, doc) {
   var nonce = Buffer.from(doc.nonce, 'hex')
   var aad = Buffer.from(doc._id)
 
-  return decrypt(key, nonce, encryptedData, aad)
+  return checkBrowser()
+
+    .then(function (result) {
+      return decrypt(key, nonce, encryptedData, aad)
+    })
 
     .then(function (outData) {
       var decrypted = JSON.parse(outData)
@@ -39,5 +44,51 @@ function decryptDoc (key, doc) {
       })
 
       return out
+    })
+}
+
+var canUseBrowserCrypto = null
+
+function checkBrowser () {
+  if (global.process && !global.process.browser) {
+    return Promise.resolve(false)
+  }
+  if (!subtle || !subtle.importKey || !subtle.encrypt) {
+    return Promise.resolve(false)
+  }
+  if (canUseBrowserCrypto != null) {
+    return Promise.resolve(canUseBrowserCrypto)
+  }
+
+  var zeroBuffy = Buffer.alloc(16, 0)
+
+  return subtle.importKey('raw', zeroBuffy, { name: 'AES-GCM' }, true, ['decrypt'])
+
+    .then(function (key) {
+      return subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: zeroBuffy.slice(0, 12),
+          additionalData: zeroBuffy.slice(0, 8)
+        },
+        key,
+        Buffer.from(
+          'A4jazmC2o5LzKMK5cbL+ePeVqqtJS1kj9/2J/5SLweAgAhEhTnOU2iCJtqzQk6vgyU2iGRG' +
+            'OKX17fry8ycOI8p7MWbwdPpusE+GvoYsO2TE=',
+          'base64'
+        )
+      )
+    })
+
+    .then(function (result) {
+      canUseBrowserCrypto = Buffer.from(result).toString('base64') ===
+        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
+
+      return canUseBrowserCrypto
+    })
+
+    .catch(function () {
+      canUseBrowserCrypto = false
+      return canUseBrowserCrypto
     })
 }

--- a/lib/decrypt.js
+++ b/lib/decrypt.js
@@ -2,8 +2,8 @@
 
 module.exports = decryptDoc
 
+var aes = require('browserify-aes')
 var assign = require('lodash/assign')
-var decrypt = require('native-crypto/decrypt')
 var Promise = require('lie')
 
 var isEncryptedObject = require('./utils/is-encrypted-object')
@@ -17,19 +17,51 @@ var subtle = global.crypto && global.crypto.subtle
 
 // Mostly copied from https://github.com/calvinmetcalf/crypto-pouch/blob/master/index.js#L157
 function decryptDoc (key, doc) {
+  if (!key || key.length !== 32) {
+    return Promise.reject(new TypeError('No valid key set! Please unlock the cryptoStore first!'))
+  }
+
   if (!isEncryptedObject(doc)) return Promise.resolve(doc)
 
   var data = Buffer.from(doc.data, 'hex')
   var tag = Buffer.from(doc.tag, 'hex')
-  var encryptedData = Buffer.concat([data, tag])
 
   var nonce = Buffer.from(doc.nonce, 'hex')
   var aad = Buffer.from(doc._id)
 
   return checkBrowser()
 
-    .then(function (result) {
-      return decrypt(key, nonce, encryptedData, aad)
+    // Original implementation from:
+    // https://github.com/calvinmetcalf/native-crypto/blob/master/browser/decrypt.js
+    .then(function (supportsBrowserCrypto) {
+      // for when the browser supports crypto.subtle
+      if (supportsBrowserCrypto) {
+        return subtle.importKey('raw', key, { name: 'AES-GCM' }, true, ['decrypt'])
+
+          .then(function (cryptoKey) {
+            var options = {
+              name: 'AES-GCM',
+              iv: nonce,
+              additionalData: aad
+            }
+
+            var encryptedData = Buffer.concat([data, tag])
+            return subtle.decrypt(options, cryptoKey, encryptedData)
+          })
+
+          .then(function (result) {
+            return Buffer.from(result).toString()
+          })
+      } else {
+        // fall back to browserify-aes
+        var cipher = aes.createDecipheriv('aes-256-gcm', key, nonce)
+        cipher.setAAD(aad)
+        cipher.setAuthTag(tag)
+
+        var output = cipher.update(data)
+        cipher.final()
+        return output.toString()
+      }
     })
 
     .then(function (outData) {

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -59,13 +59,13 @@ function encryptDoc (state, doc, prefix) {
     .then(function (supportsBrowserCrypto) {
       // for when the browser supports crypto.subtle
       if (supportsBrowserCrypto) {
-        return subtle.importKey('raw', state.key.buffer, { name: 'AES-GCM' }, true, ['encrypt'])
+        return subtle.importKey('raw', state.key, { name: 'AES-GCM' }, true, ['encrypt'])
 
           .then(function (key) {
             var options = {
               name: 'AES-GCM',
               iv: nonce,
-              additionalData: Buffer.from(outDoc._id).buffer
+              additionalData: Buffer.from(outDoc._id)
             }
 
             return subtle.encrypt(options, key, data)

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -2,15 +2,13 @@
 
 module.exports = encryptDoc
 
-var aes = require('browserify-aes')
 var includes = require('lodash/includes')
 var randomBytes = require('randombytes')
 var Promise = require('lie')
 var uuid = require('uuid').v4
 
+var encrypt = require('./helpers/encrypt-core')
 var ignore = require('./utils/ignore.js')
-
-var subtle = global.crypto && global.crypto.subtle
 
 // Mostly copied from https://github.com/calvinmetcalf/crypto-pouch/blob/master/index.js#L130
 function encryptDoc (state, doc, prefix) {
@@ -52,82 +50,11 @@ function encryptDoc (state, doc, prefix) {
   }
 
   var data = Buffer.from(JSON.stringify(encryptDoc))
-  return checkBrowser()
+  return encrypt(state.key, nonce, data, Buffer.from(outDoc._id))
 
-    // Original implementation from:
-    // https://github.com/calvinmetcalf/native-crypto/blob/master/browser/encrypt.js
-    .then(function (supportsBrowserCrypto) {
-      // for when the browser supports crypto.subtle
-      if (supportsBrowserCrypto) {
-        return subtle.importKey('raw', state.key, { name: 'AES-GCM' }, true, ['encrypt'])
-
-          .then(function (key) {
-            var options = {
-              name: 'AES-GCM',
-              iv: nonce,
-              additionalData: Buffer.from(outDoc._id)
-            }
-
-            return subtle.encrypt(options, key, data)
-          })
-
-          .then(function (response) {
-            var buffy = Buffer.from(response)
-            outDoc.tag = buffy.slice(-16).toString('hex')
-            outDoc.data = buffy.slice(0, -16).toString('hex')
-            return outDoc
-          })
-      } else {
-        // fall back to browserify-aes
-        var cipher = aes.createCipheriv('aes-256-gcm', state.key, nonce)
-        cipher.setAAD(Buffer.from(outDoc._id))
-
-        var output = cipher.update(data)
-        cipher.final()
-        var tag = cipher.getAuthTag()
-
-        outDoc.tag = tag.toString('hex')
-        outDoc.data = output.toString('hex')
-        return outDoc
-      }
-    })
-}
-
-var canUseBrowserCrypto = null
-
-function checkBrowser () {
-  if (global.process && !global.process.browser) {
-    return Promise.resolve(false)
-  }
-  if (!subtle || !subtle.importKey || !subtle.encrypt) {
-    return Promise.resolve(false)
-  }
-  if (canUseBrowserCrypto != null) {
-    return Promise.resolve(canUseBrowserCrypto)
-  }
-
-  var zeroBuffy = Buffer.alloc(32, 0)
-  var ivFaith = Buffer.alloc(12, 0)
-
-  return subtle.importKey('raw', zeroBuffy.buffer, { name: 'AES-GCM' }, true, ['encrypt'])
-
-    .then(function (key) {
-      return subtle.encrypt(
-        { name: 'AES-GCM', iv: ivFaith },
-        key,
-        zeroBuffy.buffer
-      )
-    })
-
-    .then(function (res) {
-      canUseBrowserCrypto = Buffer.from(res)
-        .toString('base64') === 'zqdAPU1ga24HTsXTuvOdGHJgA8o3pip00aL1jnUGNY7R0whMmaqKn9q7PoPrKMFd'
-
-      return canUseBrowserCrypto
-    })
-
-    .catch(function () {
-      canUseBrowserCrypto = false
-      return canUseBrowserCrypto
+    .then(function (result) {
+      outDoc.tag = result.tag
+      outDoc.data = result.data
+      return outDoc
     })
 }

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -4,10 +4,13 @@ var encrypt = require('native-crypto/encrypt')
 var randomBytes = require('randombytes')
 var uuid = require('uuid').v4
 var includes = require('lodash/includes')
+var Promise = require('lie')
 
 var ignore = require('./utils/ignore.js')
 
 module.exports = encryptDoc
+
+var subtle = global.crypto && global.crypto.subtle
 
 // Mostly copied from https://github.com/calvinmetcalf/crypto-pouch/blob/master/index.js#L130
 function encryptDoc (state, doc, prefix) {
@@ -45,11 +48,54 @@ function encryptDoc (state, doc, prefix) {
   }
 
   var data = JSON.stringify(encryptDoc)
-  return encrypt(state.key, nonce, data, Buffer.from(outDoc._id))
+  return checkBrowser()
+
+    .then(function (supportsBrowserCrypto) {
+      return encrypt(state.key, nonce, data, Buffer.from(outDoc._id))
+    })
 
     .then(function (response) {
       outDoc.tag = response.slice(-16).toString('hex')
       outDoc.data = response.slice(0, -16).toString('hex')
       return outDoc
+    })
+}
+
+var canUseBrowserCrypto = null
+
+function checkBrowser () {
+  if (global.process && !global.process.browser) {
+    return Promise.resolve(false)
+  }
+  if (!subtle || !subtle.importKey || !subtle.encrypt) {
+    return Promise.resolve(false)
+  }
+  if (canUseBrowserCrypto != null) {
+    return Promise.resolve(canUseBrowserCrypto)
+  }
+
+  var zeroBuffy = Buffer.alloc(32, 0)
+  var ivFaith = Buffer.alloc(12, 0)
+
+  return subtle.importKey('raw', zeroBuffy.buffer, { name: 'AES-GCM' }, true, ['encrypt'])
+
+    .then(function (key) {
+      return subtle.encrypt(
+        { name: 'AES-GCM', iv: ivFaith },
+        key,
+        zeroBuffy.buffer
+      )
+    })
+
+    .then(function (res) {
+      canUseBrowserCrypto = Buffer.from(res)
+        .toString('base64') === 'zqdAPU1ga24HTsXTuvOdGHJgA8o3pip00aL1jnUGNY7R0whMmaqKn9q7PoPrKMFd'
+
+      return canUseBrowserCrypto
+    })
+
+    .catch(function () {
+      canUseBrowserCrypto = false
+      return canUseBrowserCrypto
     })
 }

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -1,19 +1,23 @@
 'use strict'
 
-var encrypt = require('native-crypto/encrypt')
-var randomBytes = require('randombytes')
-var uuid = require('uuid').v4
+module.exports = encryptDoc
+
+var aes = require('browserify-aes')
 var includes = require('lodash/includes')
+var randomBytes = require('randombytes')
 var Promise = require('lie')
+var uuid = require('uuid').v4
 
 var ignore = require('./utils/ignore.js')
-
-module.exports = encryptDoc
 
 var subtle = global.crypto && global.crypto.subtle
 
 // Mostly copied from https://github.com/calvinmetcalf/crypto-pouch/blob/master/index.js#L130
 function encryptDoc (state, doc, prefix) {
+  if (!state.key || state.key.length !== 32) {
+    return Promise.reject(new TypeError('No valid key set! Please unlock the cryptoStore first!'))
+  }
+
   var nonce = randomBytes(12)
   var outDoc = {
     _id: '',
@@ -47,17 +51,45 @@ function encryptDoc (state, doc, prefix) {
     outDoc._id = prefix + outDoc._id
   }
 
-  var data = JSON.stringify(encryptDoc)
+  var data = Buffer.from(JSON.stringify(encryptDoc))
   return checkBrowser()
 
+    // Original implementation from:
+    // https://github.com/calvinmetcalf/native-crypto/blob/master/browser/encrypt.js
     .then(function (supportsBrowserCrypto) {
-      return encrypt(state.key, nonce, data, Buffer.from(outDoc._id))
-    })
+      // for when the browser supports crypto.subtle
+      if (supportsBrowserCrypto) {
+        return subtle.importKey('raw', state.key.buffer, { name: 'AES-GCM' }, true, ['encrypt'])
 
-    .then(function (response) {
-      outDoc.tag = response.slice(-16).toString('hex')
-      outDoc.data = response.slice(0, -16).toString('hex')
-      return outDoc
+          .then(function (key) {
+            var options = {
+              name: 'AES-GCM',
+              iv: nonce,
+              additionalData: Buffer.from(outDoc._id).buffer
+            }
+
+            return subtle.encrypt(options, key, data)
+          })
+
+          .then(function (response) {
+            var buffy = Buffer.from(response)
+            outDoc.tag = buffy.slice(-16).toString('hex')
+            outDoc.data = buffy.slice(0, -16).toString('hex')
+            return outDoc
+          })
+      } else {
+        // fall back to browserify-aes
+        var cipher = aes.createCipheriv('aes-256-gcm', state.key, nonce)
+        cipher.setAAD(Buffer.from(outDoc._id))
+
+        var output = cipher.update(data)
+        cipher.final()
+        var tag = cipher.getAuthTag()
+
+        outDoc.tag = tag.toString('hex')
+        outDoc.data = output.toString('hex')
+        return outDoc
+      }
     })
 }
 

--- a/lib/helpers/decrypt-core.js
+++ b/lib/helpers/decrypt-core.js
@@ -1,0 +1,99 @@
+'use strict'
+
+module.exports = decrypt
+
+var aes = require('browserify-aes')
+
+var subtle = global.crypto && global.crypto.subtle
+
+/**
+ * Decrypt data.
+ * @param {Buffer} key  - Encryption key. This is generated with the users password.
+ * @param {Buffer} iv   - Also nonce. Random bytes unique to a doc.
+ * @param {Buffer} data - The encrypted data.
+ * @param {Buffer} tag  - Part of the encrypted data.
+ * @param {Buffer} aad  - Additional data. Here always the _id of the doc.
+ * @returns {Promise}   - With the Result being a string.
+ */
+function decrypt (key, iv, data, tag, aad) {
+  return checkBrowser()
+
+    // Original implementation from:
+    // https://github.com/calvinmetcalf/native-crypto/blob/master/browser/decrypt.js
+    .then(function (supportsBrowserCrypto) {
+      // for when the browser supports crypto.subtle
+      if (supportsBrowserCrypto) {
+        return subtle.importKey('raw', key, { name: 'AES-GCM' }, true, ['decrypt'])
+
+          .then(function (cryptoKey) {
+            var options = {
+              name: 'AES-GCM',
+              iv: iv,
+              additionalData: aad
+            }
+
+            var encryptedData = Buffer.concat([data, tag])
+            return subtle.decrypt(options, cryptoKey, encryptedData)
+          })
+
+          .then(function (result) {
+            return Buffer.from(result).toString()
+          })
+      } else {
+        // fall back to browserify-aes
+        var cipher = aes.createDecipheriv('aes-256-gcm', key, iv)
+        cipher.setAAD(aad)
+        cipher.setAuthTag(tag)
+
+        var output = cipher.update(data)
+        cipher.final()
+        return output.toString()
+      }
+    })
+}
+
+var canUseBrowserCrypto = null
+
+function checkBrowser () {
+  if (global.process && !global.process.browser) {
+    return Promise.resolve(false)
+  }
+  if (!subtle || !subtle.importKey || !subtle.encrypt) {
+    return Promise.resolve(false)
+  }
+  if (canUseBrowserCrypto != null) {
+    return Promise.resolve(canUseBrowserCrypto)
+  }
+
+  var zeroBuffy = Buffer.alloc(16, 0)
+
+  return subtle.importKey('raw', zeroBuffy, { name: 'AES-GCM' }, true, ['decrypt'])
+
+    .then(function (key) {
+      return subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: zeroBuffy.slice(0, 12),
+          additionalData: zeroBuffy.slice(0, 8)
+        },
+        key,
+        Buffer.from(
+          'A4jazmC2o5LzKMK5cbL+ePeVqqtJS1kj9/2J/5SLweAgAhEhTnOU2iCJtqzQk6vgyU2iGRG' +
+            'OKX17fry8ycOI8p7MWbwdPpusE+GvoYsO2TE=',
+          'base64'
+        )
+      )
+    })
+
+    .then(function (result) {
+      canUseBrowserCrypto = Buffer.from(result).toString('base64') ===
+        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
+
+      return canUseBrowserCrypto
+    })
+
+    .catch(function () {
+      canUseBrowserCrypto = false
+      return canUseBrowserCrypto
+    })
+}

--- a/lib/helpers/decrypt-core.js
+++ b/lib/helpers/decrypt-core.js
@@ -16,6 +16,10 @@ var subtle = global.crypto && global.crypto.subtle
  * @returns {Promise}   - With the Result being a string.
  */
 function decrypt (key, iv, data, tag, aad) {
+  if (key.length !== 32) {
+    return Promise.reject(new TypeError('invalid key size'))
+  }
+
   return checkBrowser()
 
     // Original implementation from:
@@ -54,6 +58,9 @@ function decrypt (key, iv, data, tag, aad) {
 
 var canUseBrowserCrypto = null
 
+/**
+ * This checks if the browser supports crypto.subtle and the used encryption algorithm.
+ */
 function checkBrowser () {
   if (global.process && !global.process.browser) {
     return Promise.resolve(false)

--- a/lib/helpers/encrypt-core.js
+++ b/lib/helpers/encrypt-core.js
@@ -1,0 +1,100 @@
+'use strict'
+
+module.exports = encrypt
+
+var aes = require('browserify-aes')
+var Promise = require('lie')
+
+var subtle = global.crypto && global.crypto.subtle
+
+/**
+ * Encrypt data.
+ * @param {Buffer} key  - Encryption key. This is generated with the users password.
+ * @param {Buffer} iv   - Also nonce. Random bytes unique to a doc.
+ * @param {Buffer} data - The data that should be encrypted.
+ * @param {Buffer} aad  - Additional data. Here always the _id of the doc.
+ * @returns {Promise}   - An object with the keys: tag and data. Both are hex strings.
+ */
+function encrypt (key, iv, data, aad) {
+  return checkBrowser()
+
+    // Original implementation from:
+    // https://github.com/calvinmetcalf/native-crypto/blob/master/browser/encrypt.js
+    .then(function (supportsBrowserCrypto) {
+      // for when the browser supports crypto.subtle
+      if (supportsBrowserCrypto) {
+        return subtle.importKey('raw', key, { name: 'AES-GCM' }, true, ['encrypt'])
+
+          .then(function (key) {
+            var options = {
+              name: 'AES-GCM',
+              iv: iv,
+              additionalData: aad
+            }
+
+            return subtle.encrypt(options, key, data)
+          })
+
+          .then(function (response) {
+            var buffy = Buffer.from(response)
+
+            return {
+              tag: buffy.slice(-16).toString('hex'),
+              data: buffy.slice(0, -16).toString('hex')
+            }
+          })
+      } else {
+        // fall back to browserify-aes
+        var cipher = aes.createCipheriv('aes-256-gcm', key, iv)
+        cipher.setAAD(aad)
+
+        var output = cipher.update(data)
+        cipher.final()
+        var tag = cipher.getAuthTag()
+
+        return {
+          tag: tag.toString('hex'),
+          data: output.toString('hex')
+        }
+      }
+    })
+}
+
+var canUseBrowserCrypto = null
+
+function checkBrowser () {
+  if (global.process && !global.process.browser) {
+    return Promise.resolve(false)
+  }
+  if (!subtle || !subtle.importKey || !subtle.encrypt) {
+    return Promise.resolve(false)
+  }
+  if (canUseBrowserCrypto != null) {
+    return Promise.resolve(canUseBrowserCrypto)
+  }
+
+  var zeroBuffy = Buffer.alloc(32, 0)
+  var ivFaith = Buffer.alloc(12, 0)
+
+  return subtle.importKey('raw', zeroBuffy.buffer, { name: 'AES-GCM' }, true, ['encrypt'])
+
+    .then(function (key) {
+      return subtle.encrypt(
+        { name: 'AES-GCM', iv: ivFaith },
+        key,
+        zeroBuffy.buffer
+      )
+    })
+
+    .then(function (res) {
+      canUseBrowserCrypto = Buffer.from(res)
+        .toString('base64') === 'zqdAPU1ga24HTsXTuvOdGHJgA8o3pip00aL1jnUGNY7R0whMmaqKn9q7PoPrKMFd'
+
+      return canUseBrowserCrypto
+    })
+
+    .catch(function () {
+      canUseBrowserCrypto = false
+      return canUseBrowserCrypto
+    })
+}

--- a/lib/helpers/encrypt-core.js
+++ b/lib/helpers/encrypt-core.js
@@ -16,6 +16,10 @@ var subtle = global.crypto && global.crypto.subtle
  * @returns {Promise}   - An object with the keys: tag and data. Both are hex strings.
  */
 function encrypt (key, iv, data, aad) {
+  if (key.length !== 32) {
+    return Promise.reject(new TypeError('invalid key size'))
+  }
+
   return checkBrowser()
 
     // Original implementation from:
@@ -62,6 +66,9 @@ function encrypt (key, iv, data, aad) {
 
 var canUseBrowserCrypto = null
 
+/**
+ * This checks if the browser supports crypto.subtle and the used encryption algorithm.
+ */
 function checkBrowser () {
   if (global.process && !global.process.browser) {
     return Promise.resolve(false)

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -10,7 +10,7 @@ var createResetKeys = require('./helpers/create-reset-keys')
 module.exports = setup
 
 /**
- * Setup function for first run and generating a key and salt. It dosn't unlock!
+ * Setup function for first run and generating a key and salt. It doesn't unlock!
  *
  * @param  {Object}    store        instance of a hoodie client store
  * @param  {Object}    state        crypto config
@@ -86,7 +86,7 @@ function setup (store, state, password, salt) {
       var obj = objs[0]
       var resetKeys = objs[1]
 
-      // if there was an deleted salt doc: undelete it
+      // if there was an deleted salt doc: un-delete it
       if (obj._deleted) {
         obj._deleted = false
         return store.updateOrAdd(obj)

--- a/lib/unlock.js
+++ b/lib/unlock.js
@@ -1,13 +1,13 @@
 'use strict'
 
+module.exports = unlock
+
 var pouchdbErrors = require('pouchdb-errors')
 var Promise = require('lie')
-var decrypt = require('native-crypto/decrypt')
 
 var createKey = require('./create-key')
 var createPasswordCheck = require('./utils/create-password-check')
-
-module.exports = unlock
+var decrypt = require('./helpers/decrypt-core')
 
 /**
  * Unlocks the cryptoStore with the salt in hoodiePluginCryptoStore/salt
@@ -92,12 +92,11 @@ function unlock (store, state, password) {
           // check if the encrypted data in check, can be decrypted with this key.
           var data = Buffer.from(saltDoc.check.data, 'hex')
           var tag = Buffer.from(saltDoc.check.tag, 'hex')
-          var encryptedData = Buffer.concat([data, tag])
 
           var nonce = Buffer.from(saltDoc.check.nonce, 'hex')
           var aad = Buffer.from(saltDoc._id)
 
-          return decrypt(res.key, nonce, encryptedData, aad)
+          return decrypt(res.key, nonce, data, tag, aad)
 
             .then(function () {
               return res

--- a/lib/utils/create-password-check.js
+++ b/lib/utils/create-password-check.js
@@ -1,30 +1,28 @@
 'use strict'
 
-var encrypt = require('native-crypto/encrypt')
+module.exports = createPasswordCheck
+
 var randomBytes = require('randombytes')
 
-module.exports = createPasswordCheck
+var encrypt = require('../helpers/encrypt-core')
 
 /**
  * Will create the password-check of a saltDoc. It is a random string that will be encrypted.
  *
- * @param  {String}     key     crypto-key that is used to encrypt/decrypt docs.
+ * @param {String} key crypto-key that is used to encrypt/decrypt docs.
  *
  * @return {Promise}
  */
 function createPasswordCheck (key) {
   var nonce = randomBytes(12)
   var aad = Buffer.from('hoodiePluginCryptoStore/salt')
-  var passwordTest = randomBytes(64).toString('hex')
+  var passwordTest = randomBytes(64)
 
   return encrypt(key, nonce, passwordTest, aad)
 
     .then(function (encrypted) {
       // Return the check object
-      return {
-        nonce: nonce.toString('hex'),
-        tag: encrypted.slice(-16).toString('hex'),
-        data: encrypted.slice(0, -16).toString('hex')
-      }
+      encrypted.nonce = nonce.toString('hex')
+      return encrypted
     })
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "browserify-aes": "^1.2.0",
     "lie": "^3.3.0",
     "lodash": "^4.17.15",
-    "native-crypto": "^1.8.1",
     "pbkdf2": "^3.0.17",
     "pouchdb-errors": "^7.1.1",
     "randombytes": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pouchdb-replication": "^7.1.1",
     "puppeteer": "^2.0.0",
     "puppeteer-firefox": "^0.5.0",
-    "semantic-release": "^15.13.31",
+    "semantic-release": "^15.14.0",
     "standard": "^14.3.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.12.0",
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@hoodie/store-client": "^8.3.0",
+    "browserify-aes": "^1.2.0",
     "lie": "^3.3.0",
     "lodash": "^4.17.15",
     "native-crypto": "^1.8.1",

--- a/tests/unit/decrypt-test.js
+++ b/tests/unit/decrypt-test.js
@@ -178,7 +178,7 @@ test('decrypt should work in Firefox', async t => {
   t.plan(1)
 
   try {
-    const decryptedDoc = await browserTest('chrome', './lib/decrypt', 'decrypt', () => {
+    const decryptedDoc = await browserTest('firefox', './lib/decrypt', 'decrypt', () => {
       const doc = {
         _id: 'hello',
         _rev: '1-1234567890',


### PR DESCRIPTION
Fixes #93.

Changes proposed in this pull request:

- Install `browserify-aes` and uninstall `native-crypto`
- Refactor `encrypt` and `decrypt` to use `browserify-aes` and `crypto.subtle` directly

Reviewer: @Terreii
